### PR TITLE
feat(daemon): HTTP API and poll loop

### DIFF
--- a/core/src/feed.rs
+++ b/core/src/feed.rs
@@ -25,6 +25,13 @@ pub struct FeedItem {
     pub title: String,
     /// ISO 8601 (RFC 3339), taken from the entry's `pubDate`.
     pub published_at: String,
+    /// The entry's `<link>` — for a strip, its page directly; for a rant,
+    /// `https://megatokyo.com/rant/<n>`, which redirects to whichever strip
+    /// page actually hosts it (rants aren't addressable by their own page,
+    /// see `scraper::rants`). Callers that need the strip page should fetch
+    /// this URL and let the HTTP client follow the redirect, rather than
+    /// trying to derive a strip number from the rant number.
+    pub link: String,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -65,11 +72,13 @@ fn entry_to_item(entry: &Entry) -> Option<FeedItem> {
     let title = after_bracket.trim().trim_matches('"').to_string();
 
     let published = entry.published.or(entry.updated)?;
+    let link = entry.links.first()?.href.clone();
     Some(FeedItem {
         kind,
         number,
         title,
         published_at: published.to_rfc3339(),
+        link,
     })
 }
 
@@ -78,7 +87,11 @@ mod tests {
     use super::*;
 
     fn fixture() -> Vec<u8> {
-        std::fs::read(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/feed.xml")).unwrap()
+        std::fs::read(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/fixtures/feed.xml"
+        ))
+        .unwrap()
     }
 
     #[test]
@@ -96,6 +109,30 @@ mod tests {
             .find(|i| i.kind == FeedItemKind::Rant && i.number == 1107)
             .unwrap();
         assert_eq!(rant.title, "It Took Forever, But It's Here!");
+    }
+
+    #[test]
+    fn a_rant_items_link_is_its_own_permalink_not_a_strip_page() {
+        // https://megatokyo.com/rant/<n> 301-redirects to whichever strip
+        // page actually hosts that rant (verified live) — callers fetch
+        // this URL and let the HTTP client follow the redirect, rather than
+        // trying to derive a strip number from the rant number themselves.
+        let items = parse(&fixture()).unwrap();
+        let rant = items
+            .iter()
+            .find(|i| i.kind == FeedItemKind::Rant && i.number == 1107)
+            .unwrap();
+        assert_eq!(rant.link, "https://megatokyo.com/rant/1107");
+    }
+
+    #[test]
+    fn a_strip_items_link_is_its_strip_page() {
+        let items = parse(&fixture()).unwrap();
+        let strip = items
+            .iter()
+            .find(|i| i.kind == FeedItemKind::Strip && i.number == 1619)
+            .unwrap();
+        assert_eq!(strip.link, "https://megatokyo.com/strip/1619");
     }
 
     #[test]

--- a/core/src/feed.rs
+++ b/core/src/feed.rs
@@ -60,10 +60,9 @@ fn entry_to_item(entry: &Entry) -> Option<FeedItem> {
     let raw_title = entry.title.as_ref()?.content.as_str();
     let (kind, rest) = if let Some(rest) = raw_title.strip_prefix("Comic ") {
         (FeedItemKind::Strip, rest)
-    } else if let Some(rest) = raw_title.strip_prefix("Rant ") {
-        (FeedItemKind::Rant, rest)
     } else {
-        return None;
+        let rest = raw_title.strip_prefix("Rant ")?;
+        (FeedItemKind::Rant, rest)
     };
 
     let rest = rest.strip_prefix('[')?;

--- a/core/src/image_cache.rs
+++ b/core/src/image_cache.rs
@@ -76,15 +76,12 @@ impl ImageCache {
         let ext = extension_of(source_url)
             .ok_or_else(|| ImageCacheError::NoExtension(source_url.to_string()))?;
 
-        let response =
-            self.client
-                .get(source_url)
-                .send()
-                .await
-                .map_err(|source| ImageCacheError::Download {
-                    url: source_url.to_string(),
-                    source,
-                })?;
+        let response = self.client.get(source_url).send().await.map_err(|source| {
+            ImageCacheError::Download {
+                url: source_url.to_string(),
+                source,
+            }
+        })?;
         if !response.status().is_success() {
             return Err(ImageCacheError::Status {
                 url: source_url.to_string(),

--- a/core/src/local_ctrl.rs
+++ b/core/src/local_ctrl.rs
@@ -267,10 +267,7 @@ mod tests {
     #[test]
     fn extract_query_param_reads_a_value_from_the_request_line() {
         let req = "GET /rant?number=1106&lang=fr HTTP/1.1\r\nHost: x\r\n";
-        assert_eq!(
-            extract_query_param(req, "number"),
-            Some("1106".to_string())
-        );
+        assert_eq!(extract_query_param(req, "number"), Some("1106".to_string()));
         assert_eq!(extract_query_param(req, "lang"), Some("fr".to_string()));
         assert_eq!(extract_query_param(req, "missing"), None);
     }
@@ -286,7 +283,10 @@ mod tests {
 
     #[test]
     fn request_path_strips_the_query_string() {
-        assert_eq!(request_path("GET /strip?number=1619 HTTP/1.1\r\n"), "/strip");
+        assert_eq!(
+            request_path("GET /strip?number=1619 HTTP/1.1\r\n"),
+            "/strip"
+        );
     }
 
     #[test]

--- a/core/src/scraper/chapters.rs
+++ b/core/src/scraper/chapters.rs
@@ -99,8 +99,8 @@ mod tests {
         let categories: Vec<&str> = chapters.iter().map(|c| c.category.as_str()).collect();
         for expected in [
             "C-0", "C-1", "C-2", "C-3", "C-4", "C-5", "C-6", "C-7", "C-8", "C-9", "C-10", "C-11",
-            "C-12", "C-13", "OSE", "GTC", "CIR", "NNM", "UNM", "FMP", "END", "B34CH", "EVN",
-            "DPD", "SGD", "GST",
+            "C-12", "C-13", "OSE", "GTC", "CIR", "NNM", "UNM", "FMP", "END", "B34CH", "EVN", "DPD",
+            "SGD", "GST",
         ] {
             assert!(
                 categories.contains(&expected),

--- a/core/src/scraper/rants.rs
+++ b/core/src/scraper/rants.rs
@@ -26,10 +26,7 @@ pub fn parse(html: &str) -> Vec<Rant> {
     let document = Html::parse_document(html);
     let rant_sel = Selector::parse(r#"div.mainrant[id^="rant"]"#).unwrap();
 
-    document
-        .select(&rant_sel)
-        .filter_map(parse_one)
-        .collect()
+    document.select(&rant_sel).filter_map(parse_one).collect()
 }
 
 fn parse_one(container: ElementRef) -> Option<Rant> {
@@ -62,7 +59,10 @@ fn parse_one(container: ElementRef) -> Option<Rant> {
     let url = format!("https://megatokyo.com/{image_src}");
 
     let date_text = text_of(&container, "p.date")?;
-    let date_part = date_text.split_once(" - ").map(|(_, d)| d).unwrap_or(&date_text);
+    let date_part = date_text
+        .split_once(" - ")
+        .map(|(_, d)| d)
+        .unwrap_or(&date_text);
     let publish_date = date::parse(date_part.trim())?;
 
     let content = first_match(&container, ".rantbody")?.inner_html();

--- a/core/src/store.rs
+++ b/core/src/store.rs
@@ -411,7 +411,9 @@ mod tests {
         let store = Store::open_in_memory().unwrap();
         store.upsert_rant(&sample_rant()).unwrap();
         assert_eq!(store.get_translation(1106, "fr").unwrap(), None);
-        store.save_translation(1106, "fr", "<p>bonjour</p>").unwrap();
+        store
+            .save_translation(1106, "fr", "<p>bonjour</p>")
+            .unwrap();
         assert_eq!(
             store.get_translation(1106, "fr").unwrap(),
             Some("<p>bonjour</p>".to_string())

--- a/core/src/translate.rs
+++ b/core/src/translate.rs
@@ -160,7 +160,10 @@ mod tests {
     #[test]
     fn free_tier_keys_use_the_free_endpoint() {
         let translator = Translator::new("abc123:fx".to_string());
-        assert_eq!(translator.endpoint(), "https://api-free.deepl.com/v2/translate");
+        assert_eq!(
+            translator.endpoint(),
+            "https://api-free.deepl.com/v2/translate"
+        );
     }
 
     #[test]
@@ -196,7 +199,10 @@ mod tests {
             .await;
 
         let translator = Translator::with_endpoint("bad-key".to_string(), server.uri());
-        assert!(translator.translate_html("<p>hello</p>", "FR").await.is_err());
+        assert!(translator
+            .translate_html("<p>hello</p>", "FR")
+            .await
+            .is_err());
     }
 
     #[tokio::test]

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -8,4 +8,17 @@ repository.workspace = true
 description = "Background service: scrapes megatokyo.com, caches strips/rants/translations, serves the HTTP API"
 
 [dependencies]
+chrono = { version = "0.4.45", default-features = false, features = ["clock"] }
+env_logger = "0.11.11"
+log = "0.4.33"
 megatokyo-core = { path = "../core" }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+serde = { version = "1.0.229", features = ["derive"] }
+serde_json = "1.0.151"
+thiserror = "2.0.20"
+tokio = { version = "1.53.1", features = ["full"] }
+toml = "1.1.4"
+
+[dev-dependencies]
+tempfile = "3.27.0"
+wiremock = "0.6.5"

--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -1,0 +1,145 @@
+//! Daemon configuration: `$XDG_CONFIG_HOME/megatokyo-daemon/config.toml`.
+//!
+//! Unlike `core::local_ctrl`'s ephemeral per-run token (fine for a purely
+//! local control server), this daemon can be reached by remote clients that
+//! need to configure a token once and keep using it — so the API token is
+//! generated on first boot and persisted here, not regenerated on restart.
+
+use std::path::PathBuf;
+
+use megatokyo_core::local_ctrl::{generate_ctrl_token, write_owner_only_file};
+use serde::{Deserialize, Serialize};
+
+fn default_bind() -> String {
+    "127.0.0.1:8420".to_string()
+}
+
+fn default_poll_interval_minutes() -> u64 {
+    15
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Config {
+    #[serde(default = "default_bind")]
+    pub bind: String,
+    pub api_token: String,
+    #[serde(default)]
+    pub deepl_api_key: String,
+    #[serde(default = "default_poll_interval_minutes")]
+    pub poll_interval_minutes: u64,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigError {
+    #[error("could not read {path}: {source}")]
+    Read {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("could not write {path}: {source}")]
+    Write {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("could not parse {path}: {source}")]
+    Parse {
+        path: PathBuf,
+        #[source]
+        source: toml::de::Error,
+    },
+    #[error("could not serialize config: {0}")]
+    Serialize(#[from] toml::ser::Error),
+}
+
+impl Config {
+    pub fn default_path() -> PathBuf {
+        let config_home = std::env::var_os("XDG_CONFIG_HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| {
+                PathBuf::from(std::env::var_os("HOME").unwrap_or_default()).join(".config")
+            });
+        config_home.join("megatokyo-daemon").join("config.toml")
+    }
+
+    /// Loads the config at `path`, creating it with fresh defaults (and a
+    /// freshly generated `api_token`) if it doesn't exist yet.
+    pub fn load_or_init(path: &std::path::Path) -> Result<Self, ConfigError> {
+        match std::fs::read_to_string(path) {
+            Ok(contents) => toml::from_str(&contents).map_err(|source| ConfigError::Parse {
+                path: path.to_path_buf(),
+                source,
+            }),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                let config = Config {
+                    bind: default_bind(),
+                    api_token: generate_ctrl_token(),
+                    deepl_api_key: String::new(),
+                    poll_interval_minutes: default_poll_interval_minutes(),
+                };
+                config.save(path)?;
+                Ok(config)
+            }
+            Err(source) => Err(ConfigError::Read {
+                path: path.to_path_buf(),
+                source,
+            }),
+        }
+    }
+
+    pub fn save(&self, path: &std::path::Path) -> Result<(), ConfigError> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|source| ConfigError::Write {
+                path: path.to_path_buf(),
+                source,
+            })?;
+        }
+        let toml = toml::to_string_pretty(self)?;
+        write_owner_only_file(path, &toml).map_err(|source| ConfigError::Write {
+            path: path.to_path_buf(),
+            source,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn load_or_init_creates_a_config_with_a_fresh_token_when_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        assert!(!path.exists());
+
+        let config = Config::load_or_init(&path).unwrap();
+        assert!(path.exists());
+        assert_eq!(config.api_token.len(), 64);
+        assert_eq!(config.bind, "127.0.0.1:8420");
+        assert_eq!(config.poll_interval_minutes, 15);
+        assert_eq!(config.deepl_api_key, "");
+    }
+
+    #[test]
+    fn load_or_init_reuses_the_same_token_on_a_second_load() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+
+        let first = Config::load_or_init(&path).unwrap();
+        let second = Config::load_or_init(&path).unwrap();
+        assert_eq!(first.api_token, second.api_token);
+    }
+
+    #[test]
+    fn load_or_init_fills_in_defaults_for_fields_missing_from_an_older_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, "api_token = \"abc123\"\n").unwrap();
+
+        let config = Config::load_or_init(&path).unwrap();
+        assert_eq!(config.api_token, "abc123");
+        assert_eq!(config.bind, "127.0.0.1:8420");
+        assert_eq!(config.poll_interval_minutes, 15);
+    }
+}

--- a/daemon/src/control.rs
+++ b/daemon/src/control.rs
@@ -1,0 +1,385 @@
+//! Hand-rolled HTTP API — same request-parsing style as
+//! `kio-protondrive`'s local control server (see
+//! `megatokyo_core::local_ctrl`), but async (tokio) and bindable to a real
+//! network address, not just loopback: see the plan's "Déploiement
+//! distant". `/health` is the only unauthenticated route (HAProxy health
+//! checks); every other route requires the `x-megatokyo-daemon-token`
+//! header to match [`AppState::token`].
+
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use megatokyo_core::image_cache::{content_type_for, ImageCache};
+use megatokyo_core::local_ctrl::{
+    constant_time_eq, extract_header, extract_query_param, request_path,
+};
+use megatokyo_core::store::Store;
+use megatokyo_core::translate::{get_translated_rant, Translator};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+const TOKEN_HEADER: &str = "x-megatokyo-daemon-token";
+
+pub struct AppState {
+    pub store: Store,
+    pub image_cache: ImageCache,
+    pub translator: Option<Translator>,
+    pub token: String,
+    /// Set while the initial archive backfill (or a `/check`-triggered
+    /// cycle) is running — surfaced on `/status` so a client can tell "no
+    /// content yet" apart from "still loading".
+    pub backfilling: AtomicBool,
+    /// Woken by `POST /check` — the poll loop (see the poll-loop issue)
+    /// waits on this to run an out-of-schedule cycle, same
+    /// `Arc<tokio::sync::Notify>` pattern linux-hello's `hello_daemon` uses
+    /// for its own retry signal.
+    pub check_requested: tokio::sync::Notify,
+}
+
+pub async fn serve(bind: SocketAddr, state: Arc<AppState>) -> std::io::Result<()> {
+    let listener = TcpListener::bind(bind).await?;
+    log::info!("listening on {bind}");
+    loop {
+        let (stream, peer) = listener.accept().await?;
+        let state = state.clone();
+        tokio::spawn(async move {
+            if let Err(err) = handle_connection(stream, &state).await {
+                log::debug!("connection from {peer} failed: {err}");
+            }
+        });
+    }
+}
+
+async fn handle_connection(mut stream: TcpStream, state: &AppState) -> std::io::Result<()> {
+    let mut buf = vec![0u8; 8192];
+    let n = stream.read(&mut buf).await?;
+    let req = String::from_utf8_lossy(&buf[..n]).into_owned();
+    let path = request_path(&req).to_string();
+
+    let response = if path == "/health" {
+        Response::text("OK")
+    } else {
+        let token_ok = extract_header(&req, TOKEN_HEADER)
+            .map(|t| constant_time_eq(t, &state.token))
+            .unwrap_or(false);
+        if !token_ok {
+            Response {
+                status: "403 Forbidden",
+                content_type: "application/json",
+                body: b"{\"ok\":false,\"error\":\"forbidden\"}".to_vec(),
+            }
+        } else {
+            route(&req, &path, state).await
+        }
+    };
+
+    stream.write_all(&response.into_bytes()).await?;
+    Ok(())
+}
+
+struct Response {
+    status: &'static str,
+    content_type: &'static str,
+    body: Vec<u8>,
+}
+
+impl Response {
+    fn text(body: &str) -> Self {
+        Self {
+            status: "200 OK",
+            content_type: "text/plain",
+            body: body.as_bytes().to_vec(),
+        }
+    }
+
+    fn json(status: &'static str, body: String) -> Self {
+        Self {
+            status,
+            content_type: "application/json",
+            body: body.into_bytes(),
+        }
+    }
+
+    fn ok_json<T: serde::Serialize>(value: &T) -> Self {
+        Self::json("200 OK", serde_json::to_string(value).unwrap())
+    }
+
+    fn not_found() -> Self {
+        Self::json(
+            "404 Not Found",
+            "{\"ok\":false,\"error\":\"not found\"}".to_string(),
+        )
+    }
+
+    fn bad_request(message: &str) -> Self {
+        Self::json(
+            "400 Bad Request",
+            serde_json::json!({"ok": false, "error": message}).to_string(),
+        )
+    }
+
+    fn server_error(message: &str) -> Self {
+        Self::json(
+            "500 Internal Server Error",
+            serde_json::json!({"ok": false, "error": message}).to_string(),
+        )
+    }
+
+    fn into_bytes(self) -> Vec<u8> {
+        let mut out = format!(
+            "HTTP/1.1 {}\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            self.status,
+            self.content_type,
+            self.body.len()
+        )
+        .into_bytes();
+        out.extend(self.body);
+        out
+    }
+}
+
+async fn route(req: &str, path: &str, state: &AppState) -> Response {
+    match path {
+        "/chapters" => match state.store.all_chapters() {
+            Ok(chapters) => Response::ok_json(&chapters),
+            Err(err) => Response::server_error(&err.to_string()),
+        },
+        "/strips" => {
+            let result = match extract_query_param(req, "category") {
+                Some(category) => state.store.strips_by_category(&category),
+                None => state.store.all_strips(),
+            };
+            match result {
+                Ok(strips) => Response::ok_json(&strips),
+                Err(err) => Response::server_error(&err.to_string()),
+            }
+        }
+        "/strip" => route_strip(req, state),
+        "/rants" => match state.store.all_rants() {
+            Ok(rants) => Response::ok_json(&rants),
+            Err(err) => Response::server_error(&err.to_string()),
+        },
+        "/rant" => route_rant(req, state).await,
+        "/image" => route_image(req, state).await,
+        "/status" => route_status(state),
+        "/check" => {
+            state.check_requested.notify_one();
+            Response::ok_json(&serde_json::json!({"ok": true}))
+        }
+        _ => Response::not_found(),
+    }
+}
+
+fn parse_number(req: &str) -> Result<i32, Response> {
+    extract_query_param(req, "number")
+        .ok_or_else(|| Response::bad_request("missing number"))?
+        .parse()
+        .map_err(|_| Response::bad_request("number must be an integer"))
+}
+
+fn route_strip(req: &str, state: &AppState) -> Response {
+    let number = match parse_number(req) {
+        Ok(n) => n,
+        Err(response) => return response,
+    };
+    match state.store.strip_by_number(number) {
+        Ok(Some(strip)) => Response::ok_json(&strip),
+        Ok(None) => Response::not_found(),
+        Err(err) => Response::server_error(&err.to_string()),
+    }
+}
+
+async fn route_rant(req: &str, state: &AppState) -> Response {
+    let number = match parse_number(req) {
+        Ok(n) => n,
+        Err(response) => return response,
+    };
+    let lang = extract_query_param(req, "lang").unwrap_or_default();
+
+    let rant = match state.store.rant_by_number(number) {
+        Ok(Some(rant)) => rant,
+        Ok(None) => return Response::not_found(),
+        Err(err) => return Response::server_error(&err.to_string()),
+    };
+
+    let content = if lang.is_empty() || lang.eq_ignore_ascii_case("en") {
+        rant.content.clone()
+    } else {
+        let translated = match &state.translator {
+            Some(translator) => get_translated_rant(&state.store, translator, number, &lang)
+                .await
+                .map_err(|e| e.to_string()),
+            None => Err("no DeepL API key configured".to_string()),
+        };
+        match translated {
+            // `rant` above already confirmed this number exists, so
+            // get_translated_rant returning None here would mean it
+            // vanished between the two lookups — fall back to the
+            // original rather than 404 a request that clearly has one.
+            Ok(Some(content)) => content,
+            Ok(None) => rant.content.clone(),
+            Err(err) => return Response::server_error(&err),
+        }
+    };
+
+    Response::ok_json(&serde_json::json!({
+        "number": rant.number,
+        "author": rant.author,
+        "title": rant.title,
+        "url": rant.url,
+        "publish_date": rant.publish_date,
+        "lang": if lang.is_empty() { "en" } else { &lang },
+        "content": content,
+    }))
+}
+
+async fn route_image(req: &str, state: &AppState) -> Response {
+    let number = match parse_number(req) {
+        Ok(n) => n,
+        Err(response) => return response,
+    };
+    let strip = match state.store.strip_by_number(number) {
+        Ok(Some(strip)) => strip,
+        Ok(None) => return Response::not_found(),
+        Err(err) => return Response::server_error(&err.to_string()),
+    };
+    match state.image_cache.ensure_cached(number, &strip.url).await {
+        Ok(path) => match std::fs::read(&path) {
+            Ok(bytes) => Response {
+                status: "200 OK",
+                content_type: content_type_for(&path),
+                body: bytes,
+            },
+            Err(err) => Response::server_error(&err.to_string()),
+        },
+        Err(err) => Response::server_error(&err.to_string()),
+    }
+}
+
+fn route_status(state: &AppState) -> Response {
+    match state.store.get_checking() {
+        Ok(checking) => Response::ok_json(&serde_json::json!({
+            "last_check": checking.last_check,
+            "last_strip_number": checking.last_strip_number,
+            "last_rant_number": checking.last_rant_number,
+            "backfilling": state.backfilling.load(Ordering::Relaxed),
+        })),
+        Err(err) => Response::server_error(&err.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use megatokyo_core::domain::{Chapter, Rant};
+
+    fn state() -> AppState {
+        AppState {
+            store: Store::open_in_memory().unwrap(),
+            image_cache: ImageCache::new(std::env::temp_dir()),
+            translator: None,
+            token: "test-token".to_string(),
+            backfilling: AtomicBool::new(false),
+            check_requested: tokio::sync::Notify::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn health_requires_no_token() {
+        let state = state();
+        let response = route_or_health("GET /health HTTP/1.1\r\n", &state).await;
+        assert_eq!(response.status, "200 OK");
+    }
+
+    async fn route_or_health(req: &str, state: &AppState) -> Response {
+        let path = request_path(req).to_string();
+        if path == "/health" {
+            Response::text("OK")
+        } else {
+            route(req, &path, state).await
+        }
+    }
+
+    #[tokio::test]
+    async fn chapters_route_returns_stored_chapters_as_json() {
+        let state = state();
+        state
+            .store
+            .upsert_chapter(&Chapter {
+                number: 13,
+                category: "C-13".to_string(),
+                title: "Redemption".to_string(),
+            })
+            .unwrap();
+
+        let response = route("GET /chapters HTTP/1.1\r\n", "/chapters", &state).await;
+        assert_eq!(response.status, "200 OK");
+        let body: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
+        assert_eq!(body[0]["category"], "C-13");
+    }
+
+    #[tokio::test]
+    async fn strip_route_404s_for_an_unknown_number() {
+        let state = state();
+        let response = route("GET /strip?number=9999 HTTP/1.1\r\n", "/strip", &state).await;
+        assert_eq!(response.status, "404 Not Found");
+    }
+
+    #[tokio::test]
+    async fn strip_route_requires_a_number_param() {
+        let state = state();
+        let response = route("GET /strip HTTP/1.1\r\n", "/strip", &state).await;
+        assert_eq!(response.status, "400 Bad Request");
+    }
+
+    #[tokio::test]
+    async fn rant_route_returns_original_content_without_a_lang_param() {
+        let state = state();
+        state
+            .store
+            .upsert_rant(&Rant {
+                number: 1106,
+                author: "Piro".to_string(),
+                title: "Clearing of the Air".to_string(),
+                url: "https://megatokyo.com/rantimgs/1106.png".to_string(),
+                publish_date: "2023-09-27T00:00:00Z".to_string(),
+                content: "<p>hello</p>".to_string(),
+            })
+            .unwrap();
+
+        let response = route("GET /rant?number=1106 HTTP/1.1\r\n", "/rant", &state).await;
+        assert_eq!(response.status, "200 OK");
+        let body: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
+        assert_eq!(body["content"], "<p>hello</p>");
+        assert_eq!(body["lang"], "en");
+    }
+
+    #[tokio::test]
+    async fn check_route_wakes_up_a_waiting_poll_loop() {
+        let state = state();
+        let response = route("POST /check HTTP/1.1\r\n", "/check", &state).await;
+        assert_eq!(response.status, "200 OK");
+        // Should not hang: notify_one() already queued a permit before
+        // notified() is even called, since Notify remembers one
+        // "surplus" wake-up.
+        state.check_requested.notified().await;
+    }
+
+    #[tokio::test]
+    async fn status_route_reports_the_checking_checkpoint() {
+        let state = state();
+        let response = route("GET /status HTTP/1.1\r\n", "/status", &state).await;
+        assert_eq!(response.status, "200 OK");
+        let body: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
+        assert_eq!(body["last_strip_number"], 0);
+        assert_eq!(body["backfilling"], false);
+    }
+
+    #[tokio::test]
+    async fn unknown_route_404s() {
+        let state = state();
+        let response = route("GET /nope HTTP/1.1\r\n", "/nope", &state).await;
+        assert_eq!(response.status, "404 Not Found");
+    }
+}

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -1,3 +1,70 @@
-fn main() {
-    println!("megatokyo-daemon: scaffold, not yet implemented");
+mod config;
+mod control;
+mod poll;
+
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+
+use megatokyo_core::image_cache::ImageCache;
+use megatokyo_core::store::Store;
+use megatokyo_core::translate::Translator;
+
+use config::Config;
+use control::AppState;
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+
+    let config_path = Config::default_path();
+    let config = match Config::load_or_init(&config_path) {
+        Ok(config) => config,
+        Err(err) => {
+            log::error!("could not load config at {}: {err}", config_path.display());
+            std::process::exit(1);
+        }
+    };
+    log::info!("config loaded from {}", config_path.display());
+
+    let store = match Store::open(&Store::default_db_path()) {
+        Ok(store) => store,
+        Err(err) => {
+            log::error!("could not open the database: {err}");
+            std::process::exit(1);
+        }
+    };
+
+    let image_cache = ImageCache::new(ImageCache::default_cache_dir());
+    let translator =
+        (!config.deepl_api_key.is_empty()).then(|| Translator::new(config.deepl_api_key.clone()));
+
+    let state = Arc::new(AppState {
+        store,
+        image_cache,
+        translator,
+        token: config.api_token.clone(),
+        backfilling: AtomicBool::new(false),
+        check_requested: tokio::sync::Notify::new(),
+    });
+
+    let bind: std::net::SocketAddr = match config.bind.parse() {
+        Ok(addr) => addr,
+        Err(err) => {
+            log::error!("invalid bind address {:?}: {err}", config.bind);
+            std::process::exit(1);
+        }
+    };
+
+    let client = reqwest::Client::new();
+    let poll_state = state.clone();
+    let poll_client = client.clone();
+    let poll_interval = std::time::Duration::from_secs(config.poll_interval_minutes * 60);
+    tokio::spawn(async move {
+        poll::run_loop(poll_client, poll_state, poll_interval).await;
+    });
+
+    if let Err(err) = control::serve(bind, state).await {
+        log::error!("HTTP server error: {err}");
+        std::process::exit(1);
+    }
 }

--- a/daemon/src/poll.rs
+++ b/daemon/src/poll.rs
@@ -1,0 +1,272 @@
+//! Backfill + periodic poll loop — reimplements the original .NET
+//! `WebSiteParser`/`FeedManager`'s intent, not its literal logic: the
+//! original's `FeedManager.LoadAsync` only added a feed-detected item to its
+//! notification list when the item was *already* in the database (`if
+//! (await mediator.Send(new GetStripQuery(strip.Number)) != null)`), which
+//! looks backwards for "notify on new content" and is not reproduced here.
+//! This instead treats every feed item newer than the last check as
+//! something to backfill.
+//!
+//! No desktop notifications are sent from here: the daemon may run headless
+//! on a remote server (see the plan's "Déploiement distant"). Clients poll
+//! `/status` and notify themselves — see the `gui --background` issue.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use megatokyo_core::scraper::{self, strips::UnresolvedStrip};
+use megatokyo_core::{feed, store::Store};
+
+use crate::control::AppState;
+
+/// One full pass: backfill if the store is empty, then a feed diff either
+/// way (a fresh backfill's own scrape can itself lag behind the feed by the
+/// time it finishes, so this isn't an `else`).
+pub async fn run_once(client: &reqwest::Client, state: &AppState) {
+    state.backfilling.store(true, Ordering::Relaxed);
+    if let Err(err) = backfill_if_empty(client, &state.store).await {
+        log::warn!("backfill failed: {err}");
+    }
+    state.backfilling.store(false, Ordering::Relaxed);
+
+    if let Err(err) = check_feed(client, &state.store).await {
+        log::warn!("feed check failed: {err}");
+    }
+}
+
+/// Runs [`run_once`] immediately, then again every `interval`, and
+/// immediately whenever `state.check_requested` is notified (`POST
+/// /check`) — whichever comes first. A `poll_in_progress` guard (mirroring
+/// the original's `_workInProgress` flag) means an in-flight cycle just
+/// keeps running rather than being interrupted or double-started by an
+/// overlapping trigger.
+pub async fn run_loop(
+    client: reqwest::Client,
+    state: Arc<AppState>,
+    interval: std::time::Duration,
+) {
+    let poll_in_progress = AtomicBool::new(false);
+    loop {
+        if poll_in_progress
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+        {
+            run_once(&client, &state).await;
+            poll_in_progress.store(false, Ordering::SeqCst);
+        }
+        tokio::select! {
+            _ = tokio::time::sleep(interval) => {}
+            _ = state.check_requested.notified() => {}
+        }
+    }
+}
+
+async fn backfill_if_empty(
+    client: &reqwest::Client,
+    store: &Store,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if store.has_any_strip()? {
+        return Ok(());
+    }
+    log::info!("no strips in the database yet, running the initial backfill");
+    backfill(client, store).await
+}
+
+async fn backfill(
+    client: &reqwest::Client,
+    store: &Store,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let archive_html = client
+        .get(scraper::ARCHIVE_URL)
+        .send()
+        .await?
+        .text()
+        .await?;
+
+    for chapter in scraper::chapters::parse(&archive_html) {
+        store.upsert_chapter(&chapter)?;
+    }
+
+    let unresolved = scraper::strips::parse(&archive_html);
+    log::info!("backfilling {} strips", unresolved.len());
+    resolve_and_store_strips(client, store, unresolved).await;
+    Ok(())
+}
+
+/// Up to this many strip-image probes in flight at once during a backfill.
+/// The original .NET scraper probed sequentially (part of why the old
+/// UWP client's first launch was so slow, per the plan) — each probe is 1-3
+/// independent HEAD requests to megatokyo.com, so bounded concurrency here
+/// turns a ~1600-strip cold backfill from "one HTTP round-trip at a time"
+/// into a handful of seconds, without hammering the site with 1600+
+/// simultaneous connections either.
+const BACKFILL_CONCURRENCY: usize = 16;
+
+/// Resolves each strip's image extension and stores it — skips strips
+/// already in the database (matches the original's `stripsInDatabase`
+/// filter: no point re-probing megatokyo.com for a strip we already have).
+async fn resolve_and_store_strips(
+    client: &reqwest::Client,
+    store: &Store,
+    unresolved: Vec<UnresolvedStrip>,
+) {
+    let to_resolve: Vec<UnresolvedStrip> = unresolved
+        .into_iter()
+        .filter(|strip| !matches!(store.strip_by_number(strip.number), Ok(Some(_))))
+        .collect();
+
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(BACKFILL_CONCURRENCY));
+    let mut tasks = tokio::task::JoinSet::new();
+    for strip in to_resolve {
+        let client = client.clone();
+        let semaphore = semaphore.clone();
+        tasks.spawn(async move {
+            let _permit = semaphore.acquire_owned().await;
+            let number = strip.number;
+            (number, scraper::strips::resolve(&client, strip).await)
+        });
+    }
+
+    while let Some(result) = tasks.join_next().await {
+        match result {
+            Ok((number, Some(resolved))) => {
+                if let Err(err) = store.upsert_strip(&resolved) {
+                    log::warn!("could not store strip {number}: {err}");
+                }
+            }
+            Ok((number, None)) => log::warn!("could not resolve an image for strip {number}"),
+            Err(join_err) => log::warn!("strip resolve task failed: {join_err}"),
+        }
+    }
+}
+
+/// Diffs the RSS feed against the stored `checking` checkpoint, backfills
+/// any strip/rant newer than the checkpoint, and advances it.
+async fn check_feed(
+    client: &reqwest::Client,
+    store: &Store,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let items = feed::fetch(client).await?;
+    let mut checking = store.get_checking()?;
+    let last_check = checking.last_check.clone().unwrap_or_default();
+    let new_items = new_items(&items, &last_check);
+
+    if !new_items.is_empty() {
+        log::info!("{} new feed item(s) since the last check", new_items.len());
+        // A new strip/rant re-triggers an archive rescrape rather than
+        // trying to scrape just the one item from the feed alone: the feed
+        // only carries a number and a title, not the chapter/category a
+        // strip needs — archive.php is the only place that mapping lives.
+        // resolve_and_store_strips already skips strips already in the
+        // database, so this stays cheap in the common one-new-strip case.
+        if let Err(err) = backfill(client, store).await {
+            log::warn!("could not rescrape the archive after a feed change: {err}");
+        }
+        for item in &new_items {
+            if item.kind == feed::FeedItemKind::Rant {
+                if let Err(err) = fetch_and_store_rants_at(client, store, &item.link).await {
+                    log::warn!(
+                        "could not fetch rant {} at {}: {err}",
+                        item.number,
+                        item.link
+                    );
+                }
+            }
+        }
+    }
+
+    for item in &new_items {
+        match item.kind {
+            feed::FeedItemKind::Strip => checking.last_strip_number = item.number,
+            feed::FeedItemKind::Rant => checking.last_rant_number = item.number,
+        }
+    }
+    checking.last_check = Some(chrono::Utc::now().to_rfc3339());
+    store.save_checking(&checking)?;
+    Ok(())
+}
+
+/// Rants aren't addressable by their own page: `https://megatokyo.com/rant/<n>`
+/// (a feed item's `link`) 301-redirects to whichever strip page actually
+/// hosts it (verified live — see `feed::FeedItem::link`'s doc comment).
+/// `reqwest::Client` follows redirects by default, so fetching `link`
+/// directly lands on the right strip page without this daemon ever having
+/// to work out which strip that is itself.
+async fn fetch_and_store_rants_at(
+    client: &reqwest::Client,
+    store: &Store,
+    link: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let html = client.get(link).send().await?.text().await?;
+    for rant in scraper::rants::parse(&html) {
+        store.upsert_rant(&rant)?;
+    }
+    Ok(())
+}
+
+/// Feed items whose `published_at` is strictly after `last_check` — parsed
+/// as actual instants (via `DateTime::parse_from_rfc3339`), not compared as
+/// raw strings: megatokyo's feed keeps each `pubDate`'s original `-08:00`
+/// offset while `last_check` is always stored in UTC (see [`check_feed`]),
+/// so a plain string comparison would misorder them whenever the wall-clock
+/// digits happen to disagree with the actual instant (e.g. a `-08:00` 09:00
+/// pubDate is later in absolute time than a `+00:00` 10:00 checkpoint, but
+/// sorts earlier as a bare string).
+fn new_items<'a>(items: &'a [feed::FeedItem], last_check: &str) -> Vec<&'a feed::FeedItem> {
+    items
+        .iter()
+        .filter(|item| is_newer(&item.published_at, last_check))
+        .collect()
+}
+
+fn is_newer(published_at: &str, last_check: &str) -> bool {
+    let Ok(published) = chrono::DateTime::parse_from_rfc3339(published_at) else {
+        return false;
+    };
+    match chrono::DateTime::parse_from_rfc3339(last_check) {
+        Ok(last) => published > last,
+        // No valid checkpoint yet (first run: `last_check` is `""`) —
+        // everything currently in the feed counts as new.
+        Err(_) => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use megatokyo_core::feed::{FeedItem, FeedItemKind};
+
+    fn item(published_at: &str) -> FeedItem {
+        FeedItem {
+            kind: FeedItemKind::Strip,
+            number: 1,
+            title: "Sample".to_string(),
+            published_at: published_at.to_string(),
+            link: "https://megatokyo.com/strip/1".to_string(),
+        }
+    }
+
+    #[test]
+    fn everything_is_new_when_there_is_no_checkpoint_yet() {
+        let items = vec![item("2023-09-27T00:00:00Z")];
+        assert_eq!(new_items(&items, "").len(), 1);
+    }
+
+    #[test]
+    fn only_items_strictly_after_the_checkpoint_are_new() {
+        let items = vec![item("2023-09-27T00:00:00Z"), item("2023-09-26T00:00:00Z")];
+        let result = new_items(&items, "2023-09-26T12:00:00Z");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].published_at, "2023-09-27T00:00:00Z");
+    }
+
+    #[test]
+    fn compares_actual_instants_not_the_raw_string_offsets() {
+        // -08:00 09:00 is 17:00 UTC — later than a +00:00 10:00 checkpoint,
+        // even though "09" < "10" as bare text.
+        assert!(is_newer(
+            "2026-08-21T09:00:00-08:00",
+            "2026-08-21T10:00:00+00:00"
+        ));
+    }
+}


### PR DESCRIPTION
Implémente le démon (closes #1, closes #2) :

- **`control.rs`** : l'API HTTP faite main du plan (`/health`, `/chapters`, `/strips`, `/strip`, `/rants`, `/rant`, `/image`, `/status`, `/check`), protégée par jeton sauf `/health`.
- **`config.rs`** : config persistée (`$XDG_CONFIG_HOME/megatokyo-daemon/config.toml`), jeton stable généré une fois (pas régénéré à chaque run, contrairement à `local_ctrl::generate_ctrl_token` — un client distant doit pouvoir le configurer une bonne fois pour toutes).
- **`poll.rs`** : backfill initial + diff RSS périodique. Corrige au passage un bug apparent dans la logique originale .NET (`FeedManager.LoadAsync` n'ajoutait un item à notifier que s'il était *déjà* en base — voir le commentaire de doc).
- Petit bonus découvert en testant en direct : le lien RSS d'un rant (`https://megatokyo.com/rant/<n>`) redirige (301) vers la bonne page de strip — donc pas besoin de deviner un numéro de strip à partir du numéro de rant. Corrigé dans `core::feed`.
- Backfill des ~1600 strips en concurrence (16 en parallèle) plutôt que séquentiel comme l'original — le "démarrage très lent" évoqué pour l'ancienne version UWP.

Testé en direct contre megatokyo.com (environnement XDG isolé) : backfill complet en ~40s, `/strip`, `/image` (vraies images PNG), `/rants` (contenu HTML réel), auth (jeton absent/faux → 403 dans les deux cas).

76 tests passent (`cargo test --workspace`), `cargo clippy --workspace --all-targets -- -D warnings` et `cargo fmt --all -- --check` propres.

Reste à faire (issues #3-#6) : GUI (fenêtré + `--background`), écrans QML, finalisation du paquet `megatokyo-gui`.