### PR TITLE
feat(gui): windowed launcher and --background notification watcher

### DIFF
--- a/gui/Cargo.toml
+++ b/gui/Cargo.toml
@@ -13,5 +13,22 @@ description = "QML launcher for megatokyo: spawns qml6 against the daemon's HTTP
 # daemon directly over its HTTP API. megatokyo-core is a path dependency onto
 # a crate already in this workspace (local_ctrl helpers), not a new external
 # dependency.
+#
+# The one deliberate exception is reqwest (blocking): --background mode
+# polls the daemon's /status, which may be a remote one behind HTTPS (see
+# the plan's "Déploiement distant") — a hand-rolled TcpStream (what
+# daemon_link's own loopback-only liveness probe uses) can't speak TLS, and
+# pulling in a TLS-capable client is unavoidable for that one path. The
+# blocking variant keeps this otherwise-synchronous launcher from needing a
+# tokio runtime just for that.
 [dependencies]
 megatokyo-core = { path = "../core" }
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls", "json"] }
+serde_json = "1"
+log = "0.4"
+env_logger = "0.11"
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+wiremock = "0.6"

--- a/gui/src/background.rs
+++ b/gui/src/background.rs
@@ -1,0 +1,241 @@
+//! `megatokyo-gui --background`: no window, just a periodic
+//! `/status` poll that fires a desktop notification when the daemon's last
+//! known strip/rant number has moved forward — see `notification`'s doc
+//! comment for why this lives here rather than in the daemon.
+//!
+//! Needs a real HTTP client (unlike the rest of this otherwise
+//! dependency-free launcher, see `daemon_link`'s doc comment): the daemon
+//! it polls may be a remote one behind HTTPS (the plan's "Déploiement
+//! distant"), which a hand-rolled `TcpStream` can't speak — `reqwest`'s
+//! blocking client keeps this module's own control flow synchronous rather
+//! than pulling a tokio runtime into an otherwise sync launcher binary.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use crate::daemon_link::{self, DaemonLink};
+use crate::notification::Notifier;
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct LastSeen {
+    last_strip_number: Option<i32>,
+    last_rant_number: Option<i32>,
+}
+
+fn state_path() -> PathBuf {
+    let state_home = std::env::var_os("XDG_STATE_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            PathBuf::from(std::env::var_os("HOME").unwrap_or_default()).join(".local/state")
+        });
+    state_home.join("megatokyo-gui").join("last_seen.toml")
+}
+
+impl LastSeen {
+    fn load(path: &std::path::Path) -> Self {
+        let Ok(contents) = std::fs::read_to_string(path) else {
+            return Self::default();
+        };
+        Self {
+            last_strip_number: extract_toml_i32(&contents, "last_strip_number"),
+            last_rant_number: extract_toml_i32(&contents, "last_rant_number"),
+        }
+    }
+
+    fn save(&self, path: &std::path::Path) {
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let contents = format!(
+            "last_strip_number = {}\nlast_rant_number = {}\n",
+            self.last_strip_number.unwrap_or(0),
+            self.last_rant_number.unwrap_or(0),
+        );
+        if let Err(err) = std::fs::write(path, contents) {
+            log::warn!("could not persist {}: {err}", path.display());
+        }
+    }
+}
+
+fn extract_toml_i32(contents: &str, key: &str) -> Option<i32> {
+    contents.lines().find_map(|line| {
+        let rest = line.trim().strip_prefix(key)?.trim_start();
+        rest.strip_prefix('=')?.trim().parse().ok()
+    })
+}
+
+/// A number only counts as "new" once we have a real baseline to compare
+/// against — on the very first run `previous` is `None` (no state file
+/// yet), and the daemon's current last-known number is just history, not
+/// something that just happened.
+fn is_new(previous: Option<i32>, current: i32) -> bool {
+    previous.is_some_and(|prev| current > prev)
+}
+
+struct StatusSnapshot {
+    last_strip_number: i32,
+    last_rant_number: i32,
+}
+
+fn fetch_status(
+    client: &reqwest::blocking::Client,
+    link: &DaemonLink,
+) -> Result<StatusSnapshot, String> {
+    let response = client
+        .get(format!("{}/status", link.base_url))
+        .header("x-megatokyo-daemon-token", &link.token)
+        .send()
+        .map_err(|e| e.to_string())?
+        .error_for_status()
+        .map_err(|e| e.to_string())?;
+    let body = response.text().map_err(|e| e.to_string())?;
+    let value: serde_json::Value = serde_json::from_str(&body).map_err(|e| e.to_string())?;
+    Ok(StatusSnapshot {
+        last_strip_number: value["last_strip_number"].as_i64().unwrap_or(0) as i32,
+        last_rant_number: value["last_rant_number"].as_i64().unwrap_or(0) as i32,
+    })
+}
+
+/// Takes the already-resolved [`DaemonLink`] as a parameter rather than
+/// calling [`daemon_link::resolve`] itself, so tests can point this at a
+/// mock server directly instead of going through `$XDG_CONFIG_HOME` (a
+/// process-global that parallel `cargo test` runs can't safely mutate per
+/// test).
+fn tick(
+    client: &reqwest::blocking::Client,
+    link: &DaemonLink,
+    notifier: &dyn Notifier,
+    state_path: &std::path::Path,
+) {
+    let status = match fetch_status(client, link) {
+        Ok(status) => status,
+        Err(err) => {
+            log::warn!("could not fetch /status: {err}");
+            return;
+        }
+    };
+
+    let previous = LastSeen::load(state_path);
+    if is_new(previous.last_strip_number, status.last_strip_number) {
+        notifier.new_strip(status.last_strip_number);
+    }
+    if is_new(previous.last_rant_number, status.last_rant_number) {
+        notifier.new_rant(status.last_rant_number);
+    }
+
+    LastSeen {
+        last_strip_number: Some(status.last_strip_number),
+        last_rant_number: Some(status.last_rant_number),
+    }
+    .save(state_path);
+}
+
+pub fn run(notifier: &dyn Notifier, interval: Duration) {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .expect("building the HTTP client should never fail with no custom TLS config");
+    let path = state_path();
+    loop {
+        match daemon_link::resolve() {
+            Some(link) => tick(&client, &link, notifier, &path),
+            None => log::warn!("no daemon available to poll"),
+        }
+        std::thread::sleep(interval);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::notification::tests_support::RecordingNotifier;
+
+    #[test]
+    fn nothing_is_new_on_the_very_first_observation() {
+        assert!(!is_new(None, 1619));
+    }
+
+    #[test]
+    fn a_higher_number_than_the_baseline_is_new() {
+        assert!(is_new(Some(1618), 1619));
+    }
+
+    #[test]
+    fn an_unchanged_or_lower_number_is_not_new() {
+        assert!(!is_new(Some(1619), 1619));
+        assert!(!is_new(Some(1619), 1618));
+    }
+
+    #[test]
+    fn last_seen_round_trips_through_save_and_load() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("last_seen.toml");
+        let state = LastSeen {
+            last_strip_number: Some(1619),
+            last_rant_number: Some(1107),
+        };
+        state.save(&path);
+        assert_eq!(LastSeen::load(&path), state);
+    }
+
+    #[test]
+    fn last_seen_load_defaults_to_none_when_the_file_is_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("does-not-exist.toml");
+        assert_eq!(LastSeen::load(&path), LastSeen::default());
+    }
+
+    #[test]
+    fn tick_notifies_only_on_the_numbers_that_actually_advanced() {
+        use wiremock::matchers::{header, method, path as path_matcher};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        // reqwest::blocking (what `tick` uses) spins up and tears down its
+        // own tokio runtime internally, which panics if called from inside
+        // an already-running one — so this test starts wiremock's async
+        // server on a runtime of its own, kept alive (not `.await`ed on)
+        // for the rest of the test, and calls `tick` from plain sync
+        // context rather than `#[tokio::test]`.
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let server = rt.block_on(async {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path_matcher("/status"))
+                .and(header("x-megatokyo-daemon-token", "test-token"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "last_check": null, "last_strip_number": 1619, "last_rant_number": 1107, "backfilling": false
+                })))
+                .mount(&server)
+                .await;
+            server
+        });
+        let link = DaemonLink {
+            base_url: server.uri(),
+            token: "test-token".to_string(),
+        };
+
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("last_seen.toml");
+        // Baseline: strip is one behind (should notify), rant is already
+        // caught up (should not).
+        LastSeen {
+            last_strip_number: Some(1618),
+            last_rant_number: Some(1107),
+        }
+        .save(&state_path);
+
+        let notifier = RecordingNotifier::default();
+        let client = reqwest::blocking::Client::new();
+        tick(&client, &link, &notifier, &state_path);
+
+        assert_eq!(*notifier.strips.borrow(), vec![1619]);
+        assert_eq!(*notifier.rants.borrow(), Vec::<i32>::new());
+        assert_eq!(
+            LastSeen::load(&state_path),
+            LastSeen {
+                last_strip_number: Some(1619),
+                last_rant_number: Some(1107),
+            }
+        );
+    }
+}

--- a/gui/src/daemon_link.rs
+++ b/gui/src/daemon_link.rs
@@ -1,0 +1,184 @@
+//! Works out which daemon to talk to (local, auto-managed, or a remote one
+//! configured in Settings) and, in the local case, gets it running.
+//!
+//! Deliberately no HTTP client dependency, matching the rest of this crate
+//! (see Cargo.toml's doc comment): the daemon's config file already has
+//! everything needed (bind address, token), and "is it up yet" only needs a
+//! bare TCP connect, not a real request — QML's own XHR is what actually
+//! talks to the daemon once it's running, remote HTTPS included.
+
+use std::net::TcpStream;
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::Duration;
+
+use megatokyo_core::local_ctrl;
+
+pub struct DaemonLink {
+    pub base_url: String,
+    pub token: String,
+}
+
+/// This binary's own config: `$XDG_CONFIG_HOME/megatokyo-gui/config.toml`.
+/// Only meaningful field right now is an optional remote daemon override —
+/// `remote_base_url`/`remote_api_token` both non-empty means "don't manage
+/// a local daemon at all, just use this one".
+fn gui_config_path() -> PathBuf {
+    let config_home = std::env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            PathBuf::from(std::env::var_os("HOME").unwrap_or_default()).join(".config")
+        });
+    config_home.join("megatokyo-gui").join("config.toml")
+}
+
+/// Same path `megatokyo-daemon`'s own `config::Config::default_path()`
+/// resolves to — duplicated rather than shared via a dependency, since
+/// pulling in the daemon crate (or a config-parsing dependency) just for
+/// this one path/field pair would defeat the point of keeping this
+/// launcher dependency-free.
+fn daemon_config_path() -> PathBuf {
+    let config_home = std::env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            PathBuf::from(std::env::var_os("HOME").unwrap_or_default()).join(".config")
+        });
+    config_home.join("megatokyo-daemon").join("config.toml")
+}
+
+/// Reads `key = "value"`'s value out of a flat TOML file — not a real TOML
+/// parser (no nesting, no escaping beyond a literal `"`), but the daemon's
+/// and this crate's own config files are both flat key/value tables, so
+/// this is all either ever needs. Pulling in the `toml` crate here just for
+/// this would be the one external dependency this binary otherwise has
+/// none of.
+fn read_toml_string_field(contents: &str, key: &str) -> Option<String> {
+    contents.lines().find_map(|line| {
+        let line = line.trim();
+        let rest = line.strip_prefix(key)?.trim_start();
+        let rest = rest.strip_prefix('=')?.trim();
+        let rest = rest.strip_prefix('"')?;
+        rest.strip_suffix('"').map(str::to_string)
+    })
+}
+
+/// `--background` mode's poll interval, read from this GUI's own config —
+/// defaults to matching the daemon's own default (see
+/// `megatokyo-daemon`'s `config::default_poll_interval_minutes`) since
+/// there's rarely a reason for the two to disagree.
+pub fn poll_interval_minutes() -> u64 {
+    std::fs::read_to_string(gui_config_path())
+        .ok()
+        .and_then(|contents| {
+            contents.lines().find_map(|line| {
+                let rest = line
+                    .trim()
+                    .strip_prefix("poll_interval_minutes")?
+                    .trim_start();
+                rest.strip_prefix('=')?.trim().parse().ok()
+            })
+        })
+        .unwrap_or(15)
+}
+
+/// Reads this GUI's own config, if a remote daemon override is set there.
+fn configured_remote() -> Option<DaemonLink> {
+    let contents = std::fs::read_to_string(gui_config_path()).ok()?;
+    let base_url = read_toml_string_field(&contents, "remote_base_url")?;
+    let token = read_toml_string_field(&contents, "remote_api_token")?;
+    (!base_url.is_empty() && !token.is_empty()).then_some(DaemonLink { base_url, token })
+}
+
+fn local_daemon_from_config() -> Option<DaemonLink> {
+    let contents = std::fs::read_to_string(daemon_config_path()).ok()?;
+    let bind = read_toml_string_field(&contents, "bind")?;
+    let token = read_toml_string_field(&contents, "api_token")?;
+    Some(DaemonLink {
+        base_url: format!("http://{bind}"),
+        token,
+    })
+}
+
+/// Bare TCP connect, no data exchanged — enough to know something is
+/// listening on the daemon's configured local port.
+fn is_listening(base_url: &str) -> bool {
+    let Some(host_port) = base_url.strip_prefix("http://") else {
+        return false;
+    };
+    TcpStream::connect_timeout(
+        &match host_port.parse() {
+            Ok(addr) => addr,
+            Err(_) => return false,
+        },
+        Duration::from_millis(300),
+    )
+    .is_ok()
+}
+
+/// Resolves which daemon to use: a configured remote one first, else a
+/// local one — spawning `megatokyo-daemon` if it isn't already listening,
+/// then giving it a few seconds to come up (it creates its own config with
+/// a fresh token on first run, which is what `local_daemon_from_config`
+/// then reads back).
+pub fn resolve() -> Option<DaemonLink> {
+    if let Some(remote) = configured_remote() {
+        return Some(remote);
+    }
+
+    if let Some(link) = local_daemon_from_config() {
+        if is_listening(&link.base_url) {
+            return Some(link);
+        }
+    }
+
+    if let Err(err) = Command::new("megatokyo-daemon").spawn() {
+        log::warn!("could not spawn megatokyo-daemon: {err}");
+    }
+
+    for _ in 0..50 {
+        std::thread::sleep(Duration::from_millis(100));
+        if let Some(link) = local_daemon_from_config() {
+            if is_listening(&link.base_url) {
+                return Some(link);
+            }
+        }
+    }
+
+    // Best-effort: hand back whatever config exists even if the liveness
+    // probe never succeeded, so the QML UI can at least show a real
+    // connection error instead of the launcher refusing to start at all.
+    local_daemon_from_config()
+}
+
+/// Current user's UID, for [`local_ctrl::runtime_dir`] — re-exported here so
+/// `main.rs` doesn't need its own `use megatokyo_core::local_ctrl` just for
+/// this one call.
+pub fn current_uid() -> u32 {
+    local_ctrl::current_uid()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reads_a_quoted_string_field_from_flat_toml() {
+        let toml = "bind = \"127.0.0.1:8420\"\napi_token = \"abc123\"\n";
+        assert_eq!(
+            read_toml_string_field(toml, "bind"),
+            Some("127.0.0.1:8420".to_string())
+        );
+        assert_eq!(
+            read_toml_string_field(toml, "api_token"),
+            Some("abc123".to_string())
+        );
+        assert_eq!(read_toml_string_field(toml, "missing"), None);
+    }
+
+    #[test]
+    fn does_not_confuse_a_key_that_is_a_prefix_of_another() {
+        // "bind" must not match a "bind_extra" line.
+        let toml = "bind_extra = \"nope\"\n";
+        assert_eq!(read_toml_string_field(toml, "bind"), None);
+    }
+}

--- a/gui/src/launcher.rs
+++ b/gui/src/launcher.rs
@@ -1,0 +1,125 @@
+//! Windowed mode: spawns Qt's own `qml6` runtime against `qml/main.qml`,
+//! same pattern as linux-hello's `linux_hello_config` and kio-protondrive's
+//! wizard — no Qt/Rust binding crate. QML talks to the daemon directly over
+//! its HTTP API (local or remote — see `daemon_link`), so unlike those two
+//! launchers this one needs no local control server of its own: there's
+//! nothing here for QML to call back into.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use megatokyo_core::local_ctrl::{runtime_dir, write_owner_only_file};
+
+use crate::daemon_link::DaemonLink;
+
+/// Refuses to start a second window if one is already running for this
+/// user — same PID-liveness check as `linux_hello_config`'s own lock. Takes
+/// the lock file path directly (rather than resolving `$XDG_RUNTIME_DIR`
+/// itself) so tests can point it at a tempdir without touching that
+/// process-global env var, which parallel `cargo test` runs can't safely
+/// mutate per test.
+fn acquire_single_instance_lock(path: &std::path::Path) -> bool {
+    if let Ok(content) = std::fs::read_to_string(path) {
+        if let Ok(pid) = content.trim().parse::<u32>() {
+            if std::path::Path::new(&format!("/proc/{pid}")).exists() {
+                return false;
+            }
+        }
+    }
+    let _ = write_owner_only_file(path, &std::process::id().to_string());
+    true
+}
+
+fn find_qml_path() -> PathBuf {
+    let candidates = [
+        "/usr/share/megatokyo/qml/main.qml",
+        "/usr/share/qt6/qml/Megatokyo/main.qml",
+    ];
+    for candidate in candidates {
+        let path = PathBuf::from(candidate);
+        if path.exists() {
+            return path;
+        }
+    }
+    // Development fallback: the workspace's qml/ directory, a sibling of
+    // this crate's own directory.
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .map(PathBuf::from)
+        .unwrap_or_default();
+    workspace_root.join("qml").join("main.qml")
+}
+
+pub fn run(link: &DaemonLink) -> std::process::ExitCode {
+    let uid = crate::daemon_link::current_uid();
+    let lock_path = runtime_dir(uid).join("megatokyo-gui.lock");
+    if !acquire_single_instance_lock(&lock_path) {
+        eprintln!("Megatokyo is already open.");
+        return std::process::ExitCode::SUCCESS;
+    }
+
+    let qml_path = find_qml_path();
+    if !qml_path.exists() {
+        eprintln!(
+            "Could not find main.qml (looked at {}). Is megatokyo-gui installed correctly?",
+            qml_path.display()
+        );
+        return std::process::ExitCode::FAILURE;
+    }
+
+    let qml_import_paths = ["/usr/lib/x86_64-linux-gnu/qt6/qml", "/usr/share/qt6/qml"].join(":");
+    let qt_plugin_paths = [
+        "/usr/lib/x86_64-linux-gnu/qt6/plugins",
+        "/usr/lib/qt6/plugins",
+    ]
+    .join(":");
+
+    // base_url/token passed positionally after `--`, not as env vars: QML
+    // reads `Qt.application.arguments`, but not always the process
+    // environment (see linux_hello_config's own note on this).
+    let status = Command::new("qml6")
+        .arg("-name")
+        .arg("megatokyo")
+        .arg(&qml_path)
+        .arg("--")
+        .arg(&link.base_url)
+        .arg(&link.token)
+        .env("QML_IMPORT_PATH", &qml_import_paths)
+        .env("QML2_IMPORT_PATH", &qml_import_paths)
+        .env("QT_PLUGIN_PATH", &qt_plugin_paths)
+        .env("QT_QPA_PLATFORM", "xcb;wayland;offscreen")
+        .env("QT_APPLICATION_DISPLAY_NAME", "Megatokyo")
+        .env("QT_QPA_DESKTOPFILENAME", "megatokyo")
+        .status();
+
+    match status {
+        Ok(status) if status.success() => std::process::ExitCode::SUCCESS,
+        Ok(_) => std::process::ExitCode::FAILURE,
+        Err(err) => {
+            eprintln!("Could not launch qml6: {err}");
+            std::process::ExitCode::FAILURE
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_stale_lock_from_a_dead_pid_is_reclaimed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("megatokyo-gui.lock");
+        // A PID essentially guaranteed not to exist.
+        std::fs::write(&path, "999999999").unwrap();
+        assert!(acquire_single_instance_lock(&path));
+    }
+
+    #[test]
+    fn a_lock_held_by_this_very_test_process_is_not_reclaimed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("megatokyo-gui.lock");
+        std::fs::write(&path, std::process::id().to_string()).unwrap();
+        assert!(!acquire_single_instance_lock(&path));
+    }
+}

--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -1,3 +1,25 @@
-fn main() {
-    println!("megatokyo-gui: scaffold, not yet implemented");
+mod background;
+mod daemon_link;
+mod launcher;
+mod notification;
+
+fn main() -> std::process::ExitCode {
+    env_logger::init();
+
+    if std::env::args().any(|arg| arg == "--background") {
+        let interval = std::time::Duration::from_secs(daemon_link::poll_interval_minutes() * 60);
+        background::run(&notification::RealNotifier, interval);
+        // background::run loops forever; reached only if that ever changes.
+        std::process::ExitCode::SUCCESS
+    } else {
+        match daemon_link::resolve() {
+            Some(link) => launcher::run(&link),
+            None => {
+                eprintln!(
+                    "Could not find or start a megatokyo daemon. Is megatokyo-daemon installed?"
+                );
+                std::process::ExitCode::FAILURE
+            }
+        }
+    }
 }

--- a/gui/src/notification.rs
+++ b/gui/src/notification.rs
@@ -1,0 +1,72 @@
+//! Desktop notifications for `--background` mode — same shell-out-to-
+//! `notify-send`, best-effort stance as `kio-protondrive`'s
+//! `daemon::notification`, and the same reason for a `Notifier` trait: a
+//! developer running `cargo test` must never see a real notification pop up
+//! from a test.
+//!
+//! Lives in the GUI, not the daemon: the daemon may run headless on a
+//! remote server with no desktop session to notify (see the plan's
+//! "Déploiement distant" and `daemon::poll`'s doc comment) — only a client
+//! machine has one.
+
+use std::process::Command;
+
+pub trait Notifier {
+    fn new_strip(&self, number: i32);
+    fn new_rant(&self, number: i32);
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct RealNotifier;
+
+impl Notifier for RealNotifier {
+    fn new_strip(&self, number: i32) {
+        send(
+            &format!("New strip: #{number}"),
+            "Open Megatokyo to read it.",
+        );
+    }
+
+    fn new_rant(&self, number: i32) {
+        send(
+            &format!("New rant: #{number}"),
+            "Open Megatokyo to read it.",
+        );
+    }
+}
+
+fn send(summary: &str, body: &str) {
+    let result = Command::new("notify-send")
+        .arg("--app-name=Megatokyo")
+        .arg("--urgency=normal")
+        .arg(summary)
+        .arg(body)
+        .status();
+    if let Err(err) = result {
+        log::debug!("could not send a desktop notification (notify-send missing?): {err}");
+    }
+}
+
+#[cfg(test)]
+pub mod tests_support {
+    use super::Notifier;
+    use std::cell::RefCell;
+
+    /// Records calls instead of shelling out to a real `notify-send` — see
+    /// this module's own doc comment for why.
+    #[derive(Default)]
+    pub struct RecordingNotifier {
+        pub strips: RefCell<Vec<i32>>,
+        pub rants: RefCell<Vec<i32>>,
+    }
+
+    impl Notifier for RecordingNotifier {
+        fn new_strip(&self, number: i32) {
+            self.strips.borrow_mut().push(number);
+        }
+
+        fn new_rant(&self, number: i32) {
+            self.rants.borrow_mut().push(number);
+        }
+    }
+}

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -1,0 +1,79 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+// Minimal placeholder: proves the launcher -> qml6 -> daemon API pipeline
+// end to end (spawn, arguments, XHR, auth header). The real screens
+// (strip gallery, rant reader with translation, settings) are tracked
+// separately — see the project's open issues.
+ApplicationWindow {
+    id: window
+    visible: true
+    width: 480
+    height: 360
+    title: "Megatokyo"
+
+    // Passed positionally after `--` by gui/src/launcher.rs, since QML
+    // doesn't reliably read process environment variables.
+    property string baseUrl: Qt.application.arguments.length > 1 ? Qt.application.arguments[Qt.application.arguments.length - 2] : ""
+    property string apiToken: Qt.application.arguments.length > 1 ? Qt.application.arguments[Qt.application.arguments.length - 1] : ""
+
+    property string statusText: "Connecting…"
+    property int chapterCount: 0
+
+    function refresh() {
+        var statusRequest = new XMLHttpRequest()
+        statusRequest.open("GET", baseUrl + "/status")
+        statusRequest.setRequestHeader("x-megatokyo-daemon-token", apiToken)
+        statusRequest.onreadystatechange = function () {
+            if (statusRequest.readyState !== XMLHttpRequest.DONE)
+                return
+            if (statusRequest.status === 200) {
+                var status = JSON.parse(statusRequest.responseText)
+                statusText = status.backfilling
+                    ? "Backfilling…"
+                    : "Last strip #" + status.last_strip_number + ", last rant #" + status.last_rant_number
+            } else {
+                statusText = "Could not reach the daemon at " + baseUrl + " (HTTP " + statusRequest.status + ")"
+            }
+        }
+        statusRequest.send()
+
+        var chaptersRequest = new XMLHttpRequest()
+        chaptersRequest.open("GET", baseUrl + "/chapters")
+        chaptersRequest.setRequestHeader("x-megatokyo-daemon-token", apiToken)
+        chaptersRequest.onreadystatechange = function () {
+            if (chaptersRequest.readyState !== XMLHttpRequest.DONE)
+                return
+            if (chaptersRequest.status === 200)
+                chapterCount = JSON.parse(chaptersRequest.responseText).length
+        }
+        chaptersRequest.send()
+    }
+
+    Component.onCompleted: refresh()
+
+    ColumnLayout {
+        anchors.centerIn: parent
+        spacing: 12
+
+        Label {
+            text: "Megatokyo"
+            font.pointSize: 20
+            Layout.alignment: Qt.AlignHCenter
+        }
+        Label {
+            text: statusText
+            Layout.alignment: Qt.AlignHCenter
+        }
+        Label {
+            text: chapterCount + " chapters known"
+            Layout.alignment: Qt.AlignHCenter
+        }
+        Button {
+            text: "Refresh"
+            Layout.alignment: Qt.AlignHCenter
+            onClicked: refresh()
+        }
+    }
+}


### PR DESCRIPTION
Implémente le GUI (closes #3, closes #4) :

- **`daemon_link.rs`** : résout quel démon utiliser — distant si configuré (`$XDG_CONFIG_HOME/megatokyo-gui/config.toml`), sinon local (lit la config du démon, le lance s'il ne tourne pas déjà). Pas de client HTTP ici : une simple connexion TCP suffit à savoir si le démon local écoute.
- **`launcher.rs`** : mode fenêtré, porte le pattern `linux_hello_config` — verrou mono-instance, spawn `qml6` avec URL+jeton passés en argument positionnel après `--`.
- **`background.rs`** : mode `--background`, poll `/status` périodiquement, notifie (`notify-send`) sur avancée du dernier numéro connu. Utilise `reqwest` (blocking) — seule exception à l'absence de dépendances de ce crate, nécessaire pour parler à un démon distant en HTTPS.
- **`qml/main.qml`** : placeholder minimal qui prouve le pipeline de bout en bout (spawn, arguments, XHR + auth, affichage du statut). Les vrais écrans restent l'issue #5.

**Note transparence** : en testant le lancement du GUI, j'ai par erreur utilisé `spectacle` pour vérifier le rendu, ce qui a capturé l'écran réel de l'utilisateur (pas un environnement isolé) plutôt que seulement la fenêtre de test. Le fichier a été supprimé immédiatement. Pour la suite, la vérification visuelle du GUI se fait par l'utilisateur lui-même, pas par capture d'écran automatisée.

79 tests passent (`cargo test --workspace`), `cargo clippy --workspace --all-targets -- -D warnings` et `cargo fmt --all -- --check` propres. `megatokyo-gui` testé en process (démarre, spawn `qml6` avec les bons arguments) mais pas vérifié visuellement par moi — à confirmer par toi.