### PR TITLE
feat(core,daemon): favorites and reading progress

### DIFF
--- a/core/src/domain.rs
+++ b/core/src/domain.rs
@@ -32,3 +32,12 @@ pub struct Checking {
     pub last_strip_number: i32,
     pub last_rant_number: i32,
 }
+
+/// A strip number the user starred, in `favorites`. There is no user
+/// concept in the store — a daemon instance has one shared favorites list,
+/// same as it has one shared `Checking` (see `store::Store`'s doc comment).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Favorite {
+    pub strip_number: i32,
+    pub added_at: String,
+}

--- a/core/src/store.rs
+++ b/core/src/store.rs
@@ -14,7 +14,7 @@ use std::sync::Mutex;
 
 use rusqlite::{params, Connection, OptionalExtension};
 
-use crate::domain::{Chapter, Checking, Rant, Strip};
+use crate::domain::{Chapter, Checking, Favorite, Rant, Strip};
 
 #[derive(Debug, thiserror::Error)]
 pub enum StoreError {
@@ -95,6 +95,14 @@ impl Store {
                 last_check TEXT,
                 last_strip_number INTEGER NOT NULL DEFAULT 0,
                 last_rant_number INTEGER NOT NULL DEFAULT 0
+            );
+            CREATE TABLE IF NOT EXISTS favorites (
+                strip_number INTEGER PRIMARY KEY,
+                added_at TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS reading_progress (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                strip_number INTEGER NOT NULL
             );
             ",
         )?;
@@ -327,6 +335,65 @@ impl Store {
         )?;
         Ok(())
     }
+    // -- favorites ----------------------------------------------------------
+
+    /// Idempotent: starring an already-favorited strip again just keeps the
+    /// original `added_at`, so repeated clicks (or a client retrying a
+    /// dropped request) can't reorder the favorites list.
+    pub fn add_favorite(&self, strip_number: i32, added_at: &str) -> Result<()> {
+        self.conn.lock().unwrap().execute(
+            "INSERT INTO favorites (strip_number, added_at) VALUES (?1, ?2)
+             ON CONFLICT(strip_number) DO NOTHING",
+            params![strip_number, added_at],
+        )?;
+        Ok(())
+    }
+
+    pub fn remove_favorite(&self, strip_number: i32) -> Result<()> {
+        self.conn.lock().unwrap().execute(
+            "DELETE FROM favorites WHERE strip_number = ?1",
+            params![strip_number],
+        )?;
+        Ok(())
+    }
+
+    /// Most recently starred first.
+    pub fn all_favorites(&self) -> Result<Vec<Favorite>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt =
+            conn.prepare("SELECT strip_number, added_at FROM favorites ORDER BY added_at DESC")?;
+        let favorites = stmt
+            .query_map([], |row| {
+                Ok(Favorite {
+                    strip_number: row.get(0)?,
+                    added_at: row.get(1)?,
+                })
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(favorites)
+    }
+
+    // -- reading progress -----------------------------------------------------
+
+    pub fn get_reading_progress(&self) -> Result<Option<i32>> {
+        let conn = self.conn.lock().unwrap();
+        conn.query_row(
+            "SELECT strip_number FROM reading_progress WHERE id = 1",
+            [],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(StoreError::from)
+    }
+
+    pub fn save_reading_progress(&self, strip_number: i32) -> Result<()> {
+        self.conn.lock().unwrap().execute(
+            "INSERT INTO reading_progress (id, strip_number) VALUES (1, ?1)
+             ON CONFLICT(id) DO UPDATE SET strip_number = excluded.strip_number",
+            params![strip_number],
+        )?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -432,5 +499,51 @@ mod tests {
         };
         store.save_checking(&updated).unwrap();
         assert_eq!(store.get_checking().unwrap(), updated);
+    }
+
+    #[test]
+    fn favorites_round_trip_most_recent_first() {
+        let store = Store::open_in_memory().unwrap();
+        store.add_favorite(1619, "2026-08-21T00:00:00Z").unwrap();
+        store.add_favorite(42, "2026-08-22T00:00:00Z").unwrap();
+        assert_eq!(
+            store.all_favorites().unwrap(),
+            vec![
+                Favorite {
+                    strip_number: 42,
+                    added_at: "2026-08-22T00:00:00Z".to_string()
+                },
+                Favorite {
+                    strip_number: 1619,
+                    added_at: "2026-08-21T00:00:00Z".to_string()
+                },
+            ]
+        );
+        store.remove_favorite(1619).unwrap();
+        assert_eq!(store.all_favorites().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn adding_an_already_favorited_strip_again_keeps_the_original_added_at() {
+        let store = Store::open_in_memory().unwrap();
+        store.add_favorite(1619, "2026-08-21T00:00:00Z").unwrap();
+        store.add_favorite(1619, "2026-08-22T00:00:00Z").unwrap();
+        assert_eq!(
+            store.all_favorites().unwrap(),
+            vec![Favorite {
+                strip_number: 1619,
+                added_at: "2026-08-21T00:00:00Z".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn reading_progress_defaults_to_none_then_persists_updates() {
+        let store = Store::open_in_memory().unwrap();
+        assert_eq!(store.get_reading_progress().unwrap(), None);
+        store.save_reading_progress(1619).unwrap();
+        assert_eq!(store.get_reading_progress().unwrap(), Some(1619));
+        store.save_reading_progress(42).unwrap();
+        assert_eq!(store.get_reading_progress().unwrap(), Some(42));
     }
 }

--- a/daemon/src/control.rs
+++ b/daemon/src/control.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 use megatokyo_core::image_cache::{content_type_for, ImageCache};
 use megatokyo_core::local_ctrl::{
-    constant_time_eq, extract_header, extract_query_param, request_path,
+    constant_time_eq, extract_header, extract_query_param, request_method, request_path,
 };
 use megatokyo_core::store::Store;
 use megatokyo_core::translate::{get_translated_rant, Translator};
@@ -163,6 +163,8 @@ async fn route(req: &str, path: &str, state: &AppState) -> Response {
         "/rant" => route_rant(req, state).await,
         "/image" => route_image(req, state).await,
         "/status" => route_status(state),
+        "/favorites" => route_favorites(req, state),
+        "/progress" => route_progress(req, state),
         "/check" => {
             state.check_requested.notify_one();
             Response::ok_json(&serde_json::json!({"ok": true}))
@@ -266,6 +268,67 @@ fn route_status(state: &AppState) -> Response {
             "backfilling": state.backfilling.load(Ordering::Relaxed),
         })),
         Err(err) => Response::server_error(&err.to_string()),
+    }
+}
+
+/// `GET` lists favorites (most recently starred first), `POST` stars a
+/// strip, `DELETE` unstars one — no user concept, see
+/// `megatokyo_core::domain::Favorite`'s doc comment: one shared list per
+/// daemon instance, gated by the same token as everything else.
+fn route_favorites(req: &str, state: &AppState) -> Response {
+    match request_method(req) {
+        "GET" => match state.store.all_favorites() {
+            Ok(favorites) => Response::ok_json(&favorites),
+            Err(err) => Response::server_error(&err.to_string()),
+        },
+        "POST" => {
+            let number = match parse_number(req) {
+                Ok(n) => n,
+                Err(response) => return response,
+            };
+            let added_at = chrono::Utc::now().to_rfc3339();
+            match state.store.add_favorite(number, &added_at) {
+                Ok(()) => Response::ok_json(&serde_json::json!({"ok": true})),
+                Err(err) => Response::server_error(&err.to_string()),
+            }
+        }
+        "DELETE" => {
+            let number = match parse_number(req) {
+                Ok(n) => n,
+                Err(response) => return response,
+            };
+            match state.store.remove_favorite(number) {
+                Ok(()) => Response::ok_json(&serde_json::json!({"ok": true})),
+                Err(err) => Response::server_error(&err.to_string()),
+            }
+        }
+        _ => Response::not_found(),
+    }
+}
+
+/// `GET` reports the last strip number the user was reading (`null` if
+/// never set), `POST` updates it — same single-daemon-wide state as
+/// favorites, meant to let a client "resume where they left off" on any
+/// device pointed at the same daemon.
+fn route_progress(req: &str, state: &AppState) -> Response {
+    match request_method(req) {
+        "GET" => match state.store.get_reading_progress() {
+            Ok(strip_number) => Response::ok_json(&serde_json::json!({
+                "strip_number": strip_number,
+            })),
+            Err(err) => Response::server_error(&err.to_string()),
+        },
+        "POST" => {
+            let number = match parse_number(req) {
+                Ok(n) => n,
+                Err(response) => return response,
+            };
+            match state.store.save_reading_progress(number) {
+                Ok(()) => Response::ok_json(&serde_json::json!({"ok": true})),
+                Err(err) => Response::server_error(&err.to_string()),
+            }
+        }
+        _ => Response::not_found(),
     }
 }
 
@@ -374,6 +437,53 @@ mod tests {
         let body: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
         assert_eq!(body["last_strip_number"], 0);
         assert_eq!(body["backfilling"], false);
+    }
+
+    #[tokio::test]
+    async fn favorites_can_be_added_listed_and_removed() {
+        let state = state();
+        let response = route(
+            "POST /favorites?number=1619 HTTP/1.1\r\n",
+            "/favorites",
+            &state,
+        )
+        .await;
+        assert_eq!(response.status, "200 OK");
+
+        let response = route("GET /favorites HTTP/1.1\r\n", "/favorites", &state).await;
+        let body: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
+        assert_eq!(body[0]["strip_number"], 1619);
+
+        let response = route(
+            "DELETE /favorites?number=1619 HTTP/1.1\r\n",
+            "/favorites",
+            &state,
+        )
+        .await;
+        assert_eq!(response.status, "200 OK");
+        let response = route("GET /favorites HTTP/1.1\r\n", "/favorites", &state).await;
+        let body: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
+        assert_eq!(body.as_array().unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn reading_progress_is_null_until_set() {
+        let state = state();
+        let response = route("GET /progress HTTP/1.1\r\n", "/progress", &state).await;
+        let body: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
+        assert_eq!(body["strip_number"], serde_json::Value::Null);
+
+        let response = route(
+            "POST /progress?number=1619 HTTP/1.1\r\n",
+            "/progress",
+            &state,
+        )
+        .await;
+        assert_eq!(response.status, "200 OK");
+
+        let response = route("GET /progress HTTP/1.1\r\n", "/progress", &state).await;
+        let body: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
+        assert_eq!(body["strip_number"], 1619);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Ajoute deux tables (`favorites`, `reading_progress`) et les routes correspondantes (`GET/POST/DELETE /favorites`, `GET/POST /progress`) pour préparer les écrans QML détaillés dans #5 (dashboard "reprendre la lecture", bouton favoris sur le lecteur).
- Pas de notion d'utilisateur : un seul jeu de données par instance de démon, gated par le même jeton que le reste de l'API — voir la discussion sur la synchro multi-appareils dans #5.

## Test plan
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)