### PR TITLE
feat(qml): dashboard, reader, gallery and rants screens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ Cargo.lock
 *~
 .DS_Store
 
+# Claude Code local session state
+.claude/
+
 # Build artifacts
 *.so
 *.a

--- a/daemon/src/control.rs
+++ b/daemon/src/control.rs
@@ -60,10 +60,7 @@ async fn handle_connection(mut stream: TcpStream, state: &AppState) -> std::io::
     let response = if path == "/health" {
         Response::text("OK")
     } else {
-        let token_ok = extract_header(&req, TOKEN_HEADER)
-            .map(|t| constant_time_eq(t, &state.token))
-            .unwrap_or(false);
-        if !token_ok {
+        if !is_authorized(&req, &path, &state.token) {
             Response {
                 status: "403 Forbidden",
                 content_type: "application/json",
@@ -76,6 +73,20 @@ async fn handle_connection(mut stream: TcpStream, state: &AppState) -> std::io::
 
     stream.write_all(&response.into_bytes()).await?;
     Ok(())
+}
+
+/// Every route but `/health` requires the token header — except `/image`,
+/// which also accepts `?token=` since the QML `Image` element can't set a
+/// custom request header (an `<img>`-style signed-URL pattern, scoped to
+/// just this one route rather than weakening auth everywhere).
+fn is_authorized(req: &str, path: &str, token: &str) -> bool {
+    extract_header(req, TOKEN_HEADER)
+        .map(|t| constant_time_eq(t, token))
+        .unwrap_or(false)
+        || (path == "/image"
+            && extract_query_param(req, "token")
+                .map(|t| constant_time_eq(&t, token))
+                .unwrap_or(false))
 }
 
 struct Response {
@@ -353,6 +364,34 @@ mod tests {
         let state = state();
         let response = route_or_health("GET /health HTTP/1.1\r\n", &state).await;
         assert_eq!(response.status, "200 OK");
+    }
+
+    #[test]
+    fn is_authorized_accepts_the_header_on_any_route() {
+        assert!(is_authorized(
+            "GET /chapters HTTP/1.1\r\nx-megatokyo-daemon-token: secret\r\n",
+            "/chapters",
+            "secret"
+        ));
+        assert!(!is_authorized(
+            "GET /chapters HTTP/1.1\r\nx-megatokyo-daemon-token: wrong\r\n",
+            "/chapters",
+            "secret"
+        ));
+    }
+
+    #[test]
+    fn is_authorized_accepts_a_query_token_only_for_image() {
+        assert!(is_authorized(
+            "GET /image?number=1619&token=secret HTTP/1.1\r\n",
+            "/image",
+            "secret"
+        ));
+        assert!(!is_authorized(
+            "GET /chapters?token=secret HTTP/1.1\r\n",
+            "/chapters",
+            "secret"
+        ));
     }
 
     async fn route_or_health(req: &str, state: &AppState) -> Response {

--- a/gui/src/launcher.rs
+++ b/gui/src/launcher.rs
@@ -90,6 +90,10 @@ pub fn run(link: &DaemonLink) -> std::process::ExitCode {
         .env("QT_QPA_PLATFORM", "xcb;wayland;offscreen")
         .env("QT_APPLICATION_DISPLAY_NAME", "Megatokyo")
         .env("QT_QPA_DESKTOPFILENAME", "megatokyo")
+        // Qt blocks local-file XHR reads by default; I18n.qml needs one to
+        // load qml/i18n/<lang>.json (same requirement as
+        // linux_hello_config's own I18n.qml).
+        .env("QML_XHR_ALLOW_FILE_READ", "1")
         .status();
 
     match status {

--- a/qml/Api.qml
+++ b/qml/Api.qml
@@ -1,0 +1,57 @@
+import QtQuick
+
+// Thin wrapper around XMLHttpRequest for the daemon's hand-rolled HTTP API
+// (see daemon/src/control.rs) — no QML networking module beyond what Qt
+// Quick ships with, matching the rest of this project's "no extra deps"
+// stance.
+QtObject {
+    id: root
+
+    property string baseUrl: ""
+    property string token: ""
+
+    function request(method, path, onSuccess, onError) {
+        var xhr = new XMLHttpRequest()
+        xhr.open(method, baseUrl + path)
+        xhr.setRequestHeader("x-megatokyo-daemon-token", token)
+        xhr.onreadystatechange = function () {
+            if (xhr.readyState !== XMLHttpRequest.DONE)
+                return
+            if (xhr.status >= 200 && xhr.status < 300) {
+                var body = null
+                if (xhr.responseText.length > 0) {
+                    try {
+                        body = JSON.parse(xhr.responseText)
+                    } catch (e) {
+                        body = null
+                    }
+                }
+                if (onSuccess)
+                    onSuccess(body)
+            } else if (onError) {
+                onError(xhr.status, xhr.responseText)
+            }
+        }
+        xhr.send()
+    }
+
+    function get(path, onSuccess, onError) {
+        request("GET", path, onSuccess, onError)
+    }
+
+    function post(path, onSuccess, onError) {
+        request("POST", path, onSuccess, onError)
+    }
+
+    function del(path, onSuccess, onError) {
+        request("DELETE", path, onSuccess, onError)
+    }
+
+    // The daemon requires the token as a header on every other route, but
+    // QML's `Image` element can't set custom request headers — `/image`
+    // alone also accepts it as a query param (see is_authorized in
+    // daemon/src/control.rs).
+    function imageUrl(number) {
+        return baseUrl + "/image?number=" + number + "&token=" + encodeURIComponent(token)
+    }
+}

--- a/qml/DashboardScreen.qml
+++ b/qml/DashboardScreen.qml
@@ -32,9 +32,11 @@ Item {
         contentWidth: availableWidth
 
         ColumnLayout {
-            width: root.width
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.top: parent.top
+            anchors.margins: 28
             spacing: 22
-            Layout.margins: 28
 
             Label {
                 text: I18n.tr("dashboard.title")

--- a/qml/DashboardScreen.qml
+++ b/qml/DashboardScreen.qml
@@ -1,0 +1,290 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+// Home screen: last strip, last rant, resume reading, search by title/number.
+Item {
+    id: root
+
+    property var api: null
+    property var strips: []
+    property var rants: []
+    property var favorites: []
+    property int progressStrip: -1
+    property var openReader: function (number) {}
+    property var openRant: function (number) {}
+
+    readonly property var theme: Theme {}
+    readonly property var lastStrip: strips.length > 0 ? strips[strips.length - 1] : null
+    readonly property var lastRant: rants.length > 0 ? rants[0] : null
+
+    readonly property var searchResults: {
+        var q = searchField.text.trim().toLowerCase()
+        if (q.length === 0)
+            return []
+        return strips.filter(function (s) {
+            return s.title.toLowerCase().indexOf(q) !== -1 || String(s.number) === q
+        }).slice(0, 8)
+    }
+
+    ScrollView {
+        anchors.fill: parent
+        contentWidth: availableWidth
+
+        ColumnLayout {
+            width: root.width
+            spacing: 22
+            Layout.margins: 28
+
+            Label {
+                text: I18n.tr("dashboard.title")
+                font.family: theme.fontDisplay
+                font.pixelSize: 20
+                font.bold: true
+                color: theme.text
+            }
+
+            // -- search --------------------------------------------------
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 4
+
+                Rectangle {
+                    Layout.preferredWidth: 440
+                    Layout.preferredHeight: 40
+                    radius: 10
+                    color: theme.panelSunken
+                    border.color: theme.line
+                    border.width: 1
+
+                    TextField {
+                        id: searchField
+                        anchors.fill: parent
+                        anchors.margins: 8
+                        background: null
+                        color: theme.text
+                        placeholderText: I18n.tr("dashboard.searchPlaceholder")
+                        placeholderTextColor: theme.textFaint
+                        selectByMouse: true
+                    }
+                }
+
+                Rectangle {
+                    visible: searchResults.length > 0
+                    Layout.preferredWidth: 440
+                    Layout.preferredHeight: Math.min(searchResults.length, 6) * 34
+                    color: theme.panelRaised
+                    border.color: theme.lineSoft
+                    border.width: 1
+                    radius: 8
+
+                    ListView {
+                        anchors.fill: parent
+                        anchors.margins: 4
+                        model: searchResults
+                        delegate: ItemDelegate {
+                            id: resultDelegate
+                            width: parent ? parent.width : 0
+                            height: 30
+                            text: "#" + modelData.number + "  " + modelData.title
+                            font.family: theme.fontBody
+                            font.pixelSize: 12
+                            contentItem: Label {
+                                text: resultDelegate.text
+                                color: theme.text
+                                font: resultDelegate.font
+                                verticalAlignment: Text.AlignVCenter
+                                leftPadding: 8
+                            }
+                            background: Rectangle {
+                                color: hovered ? theme.panel : "transparent"
+                            }
+                            onClicked: {
+                                searchField.text = ""
+                                root.openReader(modelData.number)
+                            }
+                        }
+                    }
+                }
+            }
+
+            // -- last strip / last rant -----------------------------------
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: 16
+
+                Rectangle {
+                    Layout.fillWidth: true
+                    Layout.preferredWidth: 2
+                    Layout.preferredHeight: 130
+                    radius: 12
+                    color: theme.panelRaised
+                    border.color: theme.lineSoft
+                    border.width: 1
+                    visible: root.lastStrip !== null
+
+                    RowLayout {
+                        anchors.fill: parent
+                        anchors.margins: 16
+                        spacing: 14
+
+                        Rectangle {
+                            Layout.preferredWidth: 108
+                            Layout.preferredHeight: 78
+                            radius: 8
+                            color: theme.panelSunken
+                            border.color: theme.line
+                            border.width: 1
+                            clip: true
+
+                            Image {
+                                anchors.fill: parent
+                                source: root.lastStrip ? api.imageUrl(root.lastStrip.number) : ""
+                                fillMode: Image.PreserveAspectCrop
+                                asynchronous: true
+                            }
+                        }
+
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 6
+
+                            Label {
+                                text: I18n.tr("dashboard.lastStripLabel")
+                                color: theme.teal
+                                font.family: theme.fontMono
+                                font.pixelSize: 10
+                            }
+                            Label {
+                                text: root.lastStrip ? ("#" + root.lastStrip.number) : ""
+                                color: theme.textFaint
+                                font.family: theme.fontMono
+                                font.pixelSize: 11
+                            }
+                            Label {
+                                text: root.lastStrip ? root.lastStrip.title : ""
+                                color: theme.text
+                                font.family: theme.fontDisplay
+                                font.pixelSize: 16
+                                font.bold: true
+                            }
+                            Button {
+                                id: resumeButton
+                                text: I18n.tr("dashboard.resumeReading")
+                                enabled: root.progressStrip > 0 || root.lastStrip !== null
+                                onClicked: root.openReader(root.progressStrip > 0 ? root.progressStrip : root.lastStrip.number)
+                                background: Rectangle {
+                                    color: theme.teal
+                                    radius: 8
+                                }
+                                contentItem: Label {
+                                    text: resumeButton.text
+                                    color: theme.ink
+                                    font.bold: true
+                                    font.pixelSize: 12
+                                    horizontalAlignment: Text.AlignHCenter
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Rectangle {
+                    Layout.fillWidth: true
+                    Layout.preferredWidth: 1
+                    Layout.preferredHeight: 130
+                    radius: 12
+                    color: theme.panelRaised
+                    border.color: theme.lineSoft
+                    border.width: 1
+                    visible: root.lastRant !== null
+
+                    ColumnLayout {
+                        anchors.fill: parent
+                        anchors.margins: 16
+                        spacing: 6
+
+                        Label {
+                            text: I18n.tr("dashboard.lastRantLabel")
+                            color: theme.teal
+                            font.family: theme.fontMono
+                            font.pixelSize: 10
+                        }
+                        Label {
+                            text: root.lastRant ? root.lastRant.title : ""
+                            color: theme.text
+                            font.family: theme.fontDisplay
+                            font.pixelSize: 15
+                            font.bold: true
+                            Layout.fillWidth: true
+                            wrapMode: Text.WordWrap
+                        }
+                        Label {
+                            text: root.lastRant ? (root.lastRant.author + " · #" + root.lastRant.number) : ""
+                            color: theme.textFaint
+                            font.family: theme.fontMono
+                            font.pixelSize: 10
+                        }
+                        Item { Layout.fillHeight: true }
+                        Button {
+                            id: readPostButton
+                            text: I18n.tr("dashboard.readPost")
+                            onClicked: root.lastRant && root.openRant(root.lastRant.number)
+                            background: Rectangle {
+                                color: "transparent"
+                                border.color: theme.line
+                                border.width: 1
+                                radius: 8
+                            }
+                            contentItem: Label {
+                                text: readPostButton.text
+                                color: theme.text
+                                font.pixelSize: 12
+                                horizontalAlignment: Text.AlignHCenter
+                            }
+                        }
+                    }
+                }
+            }
+
+            // -- stats ------------------------------------------------------
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: 12
+
+                Repeater {
+                    model: [
+                        { n: root.strips.length, l: I18n.tr("dashboard.statsStrips") },
+                        { n: root.favorites.length, l: I18n.tr("dashboard.statsFavorites") },
+                        { n: root.rants.length, l: I18n.tr("dashboard.statsRants") }
+                    ]
+                    delegate: Rectangle {
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: 62
+                        radius: 12
+                        color: theme.panelRaised
+                        border.color: theme.lineSoft
+                        border.width: 1
+
+                        ColumnLayout {
+                            anchors.fill: parent
+                            anchors.margins: 13
+                            spacing: 2
+                            Label {
+                                text: modelData.n
+                                color: theme.text
+                                font.family: theme.fontMono
+                                font.pixelSize: 19
+                            }
+                            Label {
+                                text: modelData.l
+                                color: theme.textDim
+                                font.pixelSize: 11
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/qml/GalleryScreen.qml
+++ b/qml/GalleryScreen.qml
@@ -1,0 +1,151 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+// Gallery screen: strip thumbnails grouped by chapter/category, with a
+// favorites filter — same category/chapter model as ReaderScreen.
+Item {
+    id: root
+
+    property var api: null
+    property var strips: []
+    property var chapters: []
+    property var favorites: []
+    property var openReader: function (number) {}
+
+    readonly property var theme: Theme {}
+
+    // "all" | "favorites" | a chapter's category string
+    property string selectedFilter: "all"
+
+    readonly property var chipModel: {
+        var items = [{ key: "all", label: I18n.tr("gallery.chipAll") }]
+        chapters.forEach(function (c) {
+            items.push({ key: c.category, label: c.title })
+        })
+        items.push({ key: "favorites", label: I18n.tr("gallery.chipFavorites") })
+        return items
+    }
+
+    readonly property var favoriteNumbers: favorites.map(function (f) {
+        return f.strip_number
+    })
+
+    readonly property var filteredStrips: {
+        if (selectedFilter === "all")
+            return strips
+        if (selectedFilter === "favorites")
+            return strips.filter(function (s) {
+                return root.favoriteNumbers.indexOf(s.number) !== -1
+            })
+        return strips.filter(function (s) {
+            return s.category === selectedFilter
+        })
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 28
+        spacing: 16
+
+        Label {
+            text: I18n.tr("gallery.title")
+            font.family: theme.fontDisplay
+            font.pixelSize: 20
+            font.bold: true
+            color: theme.text
+        }
+
+        Flow {
+            Layout.fillWidth: true
+            spacing: 8
+
+            Repeater {
+                model: root.chipModel
+                delegate: Rectangle {
+                    height: 28
+                    width: chipLabel.implicitWidth + 24
+                    radius: 999
+                    color: root.selectedFilter === modelData.key ? theme.tealDim : "transparent"
+                    border.color: root.selectedFilter === modelData.key ? theme.tealDim : theme.line
+                    border.width: 1
+
+                    Label {
+                        id: chipLabel
+                        anchors.centerIn: parent
+                        text: modelData.label
+                        font.pixelSize: 12
+                        color: root.selectedFilter === modelData.key ? theme.teal : theme.textDim
+                    }
+                    MouseArea {
+                        anchors.fill: parent
+                        onClicked: root.selectedFilter = modelData.key
+                    }
+                }
+            }
+        }
+
+        GridView {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            cellWidth: 128
+            cellHeight: 168
+            clip: true
+            model: root.filteredStrips
+
+            delegate: Item {
+                width: 120
+                height: 158
+
+                Rectangle {
+                    anchors.fill: parent
+                    radius: 9
+                    color: theme.panelSunken
+                    border.color: theme.lineSoft
+                    border.width: 1
+                    clip: true
+
+                    Image {
+                        anchors.fill: parent
+                        source: root.api ? root.api.imageUrl(modelData.number) : ""
+                        fillMode: Image.PreserveAspectCrop
+                        asynchronous: true
+                    }
+
+                    Rectangle {
+                        anchors.left: parent.left
+                        anchors.bottom: parent.bottom
+                        anchors.margins: 6
+                        width: numLabel.implicitWidth + 10
+                        height: 18
+                        radius: 5
+                        color: Qt.rgba(0.05, 0.05, 0.07, 0.75)
+                        Label {
+                            id: numLabel
+                            anchors.centerIn: parent
+                            text: "#" + modelData.number
+                            font.family: theme.fontMono
+                            font.pixelSize: 10
+                            color: theme.text
+                        }
+                    }
+
+                    Label {
+                        visible: root.favoriteNumbers.indexOf(modelData.number) !== -1
+                        anchors.top: parent.top
+                        anchors.right: parent.right
+                        anchors.margins: 6
+                        text: "♥"
+                        color: theme.red
+                        font.pixelSize: 13
+                    }
+
+                    MouseArea {
+                        anchors.fill: parent
+                        onClicked: root.openReader(modelData.number)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/qml/I18n.qml
+++ b/qml/I18n.qml
@@ -1,0 +1,78 @@
+pragma Singleton
+import QtQuick
+
+// Ported from linux_hello_config's own I18n.qml (same author, same
+// pattern): JSON dictionaries under i18n/<lang>.json, loaded via a
+// synchronous local-file XHR (requires QML_XHR_ALLOW_FILE_READ=1, set by
+// gui::launcher when it spawns qml6 — Qt blocks local-file XHR reads by
+// default otherwise). en.json is the single source of truth for English
+// strings, not duplicated here.
+QtObject {
+    id: i18n
+
+    property var translations: ({})
+    property string currentLanguage: "en"
+
+    readonly property var languages: ["en", "fr", "es", "de", "ru", "ja", "zh", "ar", "hi", "pt"]
+    readonly property var languageNames: ({
+        "en": "English",
+        "fr": "Français (French)",
+        "es": "Español (Spanish)",
+        "de": "Deutsch (German)",
+        "ru": "Русский (Russian)",
+        "ja": "日本語 (Japanese)",
+        "zh": "中文 (Chinese)",
+        "ar": "العربية (Arabic)",
+        "hi": "हिंदी (Hindi)",
+        "pt": "Português (Portuguese)"
+    })
+
+    function loadLanguage(lang) {
+        var qmlPath = Qt.resolvedUrl("./i18n/" + lang + ".json")
+        var xhr = new XMLHttpRequest()
+        xhr.open("GET", qmlPath, false)
+        try {
+            xhr.send()
+            if (xhr.status === 200) {
+                var loaded = JSON.parse(xhr.responseText)
+                if (loaded && typeof loaded === 'object') {
+                    translations = loaded
+                    currentLanguage = lang
+                    return true
+                }
+            }
+        } catch (e) {
+            // Silent fallback — tr() returns raw keys for anything missing.
+        }
+
+        currentLanguage = lang
+        return true
+    }
+
+    function tr(key) {
+        if (!key || key === "")
+            return key
+
+        if (key in translations)
+            return translations[key]
+
+        var keys = key.split('.')
+        var value = translations
+        for (var i = 0; i < keys.length; i++) {
+            if (value && typeof value === 'object' && keys[i] in value) {
+                value = value[keys[i]]
+            } else {
+                return key
+            }
+        }
+        return typeof value === 'string' ? value : key
+    }
+
+    Component.onCompleted: {
+        var systemLang = Qt.locale().name.substring(0, 2).toLowerCase()
+        if (languages.includes(systemLang))
+            loadLanguage(systemLang)
+        else
+            loadLanguage("en")
+    }
+}

--- a/qml/RantsScreen.qml
+++ b/qml/RantsScreen.qml
@@ -1,0 +1,186 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+// Rants screen: list + detail, with a language picker that calls
+// GET /rant?number=N&lang=xx (cached server-side by the daemon after the
+// first translation, see core::translate) — this screen keeps its own
+// per-session cache too, so switching back to an already-seen language is
+// instant.
+Item {
+    id: root
+
+    property var api: null
+    property var rants: []
+    property int selectedNumber: -1
+
+    readonly property var theme: Theme {}
+
+    readonly property var languages: [
+        { code: "en", label: "EN" },
+        { code: "fr", label: "FR" },
+        { code: "de", label: "DE" },
+        { code: "ja", label: "JA" }
+    ]
+    property string selectedLang: "en"
+    property var translationCache: ({})
+    property bool loadingTranslation: false
+
+    readonly property var selectedRant: rants.find(function (r) {
+        return r.number === selectedNumber
+    })
+
+    readonly property string displayedContent: {
+        if (!selectedRant)
+            return ""
+        if (selectedLang === "en")
+            return selectedRant.content
+        var key = selectedRant.number + "_" + selectedLang
+        return translationCache[key] !== undefined ? translationCache[key] : ""
+    }
+
+    onRantsChanged: {
+        if (selectedNumber === -1 && rants.length > 0)
+            selectedNumber = rants[0].number
+    }
+
+    function selectLang(code) {
+        selectedLang = code
+        if (code === "en" || !selectedRant)
+            return
+        var key = selectedRant.number + "_" + code
+        if (translationCache[key] !== undefined)
+            return
+        loadingTranslation = true
+        api.get("/rant?number=" + selectedRant.number + "&lang=" + code, function (body) {
+            var updated = Object.assign({}, translationCache)
+            updated[key] = body.content
+            translationCache = updated
+            loadingTranslation = false
+        }, function () {
+            loadingTranslation = false
+        })
+    }
+
+    RowLayout {
+        anchors.fill: parent
+        anchors.margins: 28
+        spacing: 20
+
+        ColumnLayout {
+            Layout.preferredWidth: 220
+            Layout.fillHeight: true
+            spacing: 12
+
+            Label {
+                text: I18n.tr("rants.title")
+                font.family: theme.fontDisplay
+                font.pixelSize: 20
+                font.bold: true
+                color: theme.text
+            }
+
+            ListView {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                clip: true
+                model: root.rants
+                delegate: Rectangle {
+                    width: ListView.view.width
+                    height: 46
+                    radius: 9
+                    color: modelData.number === root.selectedNumber ? theme.panelRaised : "transparent"
+                    border.color: modelData.number === root.selectedNumber ? theme.lineSoft : "transparent"
+                    border.width: 1
+
+                    ColumnLayout {
+                        anchors.fill: parent
+                        anchors.margins: 8
+                        spacing: 1
+                        Label {
+                            text: "#" + modelData.number + " · " + modelData.publish_date.slice(0, 10)
+                            font.family: theme.fontMono
+                            font.pixelSize: 9
+                            color: theme.textFaint
+                        }
+                        Label {
+                            text: modelData.title
+                            font.pixelSize: 12
+                            color: modelData.number === root.selectedNumber ? theme.teal : theme.text
+                            elide: Text.ElideRight
+                            Layout.fillWidth: true
+                        }
+                    }
+                    MouseArea {
+                        anchors.fill: parent
+                        onClicked: {
+                            root.selectedNumber = modelData.number
+                            root.selectedLang = "en"
+                        }
+                    }
+                }
+            }
+        }
+
+        ColumnLayout {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            spacing: 8
+
+            Label {
+                text: root.selectedRant ? root.selectedRant.title : ""
+                font.family: theme.fontDisplay
+                font.pixelSize: 18
+                font.bold: true
+                color: theme.text
+                Layout.fillWidth: true
+                wrapMode: Text.WordWrap
+            }
+            Label {
+                text: root.selectedRant ? (root.selectedRant.author + " · #" + root.selectedRant.number + " · " + root.selectedRant.publish_date.slice(0, 10)) : ""
+                font.family: theme.fontMono
+                font.pixelSize: 11
+                color: theme.textFaint
+            }
+
+            Row {
+                spacing: 6
+                Repeater {
+                    model: root.languages
+                    delegate: Rectangle {
+                        width: 40; height: 24; radius: 6
+                        color: root.selectedLang === modelData.code ? theme.teal : "transparent"
+                        border.color: root.selectedLang === modelData.code ? theme.teal : theme.line
+                        border.width: 1
+                        Label {
+                            anchors.centerIn: parent
+                            text: modelData.label
+                            font.family: theme.fontMono
+                            font.pixelSize: 10
+                            color: root.selectedLang === modelData.code ? theme.ink : theme.textDim
+                        }
+                        MouseArea {
+                            anchors.fill: parent
+                            onClicked: root.selectLang(modelData.code)
+                        }
+                    }
+                }
+            }
+
+            ScrollView {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+
+                Label {
+                    width: parent.width
+                    text: root.loadingTranslation ? I18n.tr("rants.loadingTranslation") : root.displayedContent
+                    textFormat: Text.RichText
+                    wrapMode: Text.WordWrap
+                    color: theme.textDim
+                    font.pixelSize: 13
+                    lineHeight: 1.5
+                }
+            }
+        }
+    }
+}

--- a/qml/ReaderScreen.qml
+++ b/qml/ReaderScreen.qml
@@ -1,0 +1,251 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+// Reader screen: strip-by-strip navigation, "all strips" vs "main story
+// only" (chapters with a non-zero number — bonus/bonus-like sections parse
+// to category number 0, see core::scraper::chapters), favorites, and
+// quick-jump to a chapter/category or to favorites.
+Item {
+    id: root
+
+    property var api: null
+    property var strips: []
+    property var chapters: []
+    property var favorites: []
+    property var toggleFavorite: function (number) {}
+    property var saveProgress: function (number) {}
+
+    property int currentNumber: -1
+    property bool mainStoryOnly: false
+
+    readonly property var theme: Theme {}
+
+    readonly property var mainStoryCategories: chapters.filter(function (c) {
+        return c.number > 0
+    }).map(function (c) {
+        return c.category
+    })
+
+    readonly property var filteredStrips: {
+        if (!mainStoryOnly)
+            return strips
+        return strips.filter(function (s) {
+            return mainStoryCategories.indexOf(s.category) !== -1
+        })
+    }
+
+    readonly property int currentIndex: filteredStrips.findIndex(function (s) {
+        return s.number === currentNumber
+    })
+
+    readonly property var currentStrip: strips.find(function (s) {
+        return s.number === currentNumber
+    })
+
+    readonly property bool isFavorite: favorites.some(function (f) {
+        return f.strip_number === currentNumber
+    })
+
+    readonly property var jumpModel: {
+        var items = chapters.map(function (c) {
+            return {
+                category: c.category,
+                label: (c.number > 0 ? I18n.tr("reader.jumpChapter") + " " + c.number : I18n.tr("reader.jumpBonus")) + " — " + c.title
+            }
+        })
+        items.push({ category: "__favorites__", label: I18n.tr("reader.jumpFavorites") })
+        return items
+    }
+
+    function goTo(delta) {
+        var list = filteredStrips
+        var idx = currentIndex
+        var next = idx + delta
+        if (idx === -1 && list.length > 0) {
+            currentNumber = list[0].number
+            return
+        }
+        if (next >= 0 && next < list.length)
+            currentNumber = list[next].number
+    }
+
+    onCurrentNumberChanged: {
+        if (currentNumber > 0)
+            saveProgress(currentNumber)
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 28
+        spacing: 16
+
+        Label {
+            text: I18n.tr("reader.title")
+            font.family: theme.fontDisplay
+            font.pixelSize: 20
+            font.bold: true
+            color: theme.text
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+
+            Row {
+                spacing: 2
+                Rectangle {
+                    width: 260; height: 30; radius: 9
+                    color: theme.panelSunken
+                    border.color: theme.line
+                    border.width: 1
+
+                    Row {
+                        anchors.fill: parent
+                        anchors.margins: 2
+
+                        Rectangle {
+                            width: parent.width / 2; height: parent.height
+                            radius: 7
+                            color: !root.mainStoryOnly ? theme.panelRaised : "transparent"
+                            Label {
+                                anchors.centerIn: parent
+                                width: parent.width - 8
+                                horizontalAlignment: Text.AlignHCenter
+                                elide: Text.ElideRight
+                                text: I18n.tr("reader.segAll")
+                                font.pixelSize: 11
+                                color: !root.mainStoryOnly ? theme.text : theme.textDim
+                            }
+                            MouseArea { anchors.fill: parent; onClicked: root.mainStoryOnly = false }
+                        }
+                        Rectangle {
+                            width: parent.width / 2; height: parent.height
+                            radius: 7
+                            color: root.mainStoryOnly ? theme.panelRaised : "transparent"
+                            Label {
+                                anchors.centerIn: parent
+                                width: parent.width - 8
+                                horizontalAlignment: Text.AlignHCenter
+                                elide: Text.ElideRight
+                                text: I18n.tr("reader.segMain")
+                                font.pixelSize: 11
+                                color: root.mainStoryOnly ? theme.text : theme.textDim
+                            }
+                            MouseArea { anchors.fill: parent; onClicked: root.mainStoryOnly = true }
+                        }
+                    }
+                }
+            }
+
+            Item { Layout.fillWidth: true }
+
+            ComboBox {
+                Layout.preferredWidth: 220
+                model: root.jumpModel
+                textRole: "label"
+                onActivated: function (index) {
+                    var item = root.jumpModel[index]
+                    if (item.category === "__favorites__") {
+                        if (root.favorites.length > 0)
+                            root.currentNumber = root.favorites[0].strip_number
+                    } else {
+                        var matches = root.strips.filter(function (s) {
+                            return s.category === item.category
+                        })
+                        if (matches.length > 0)
+                            root.currentNumber = matches[0].number
+                    }
+                }
+            }
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            spacing: 14
+
+            ToolButton {
+                text: "‹"
+                enabled: root.currentIndex > 0
+                onClicked: root.goTo(-1)
+                contentItem: Label { text: "‹"; color: theme.text; font.pixelSize: 18; horizontalAlignment: Text.AlignHCenter }
+            }
+
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                radius: 10
+                color: theme.panelSunken
+                border.color: theme.line
+                border.width: 1
+                clip: true
+
+                Image {
+                    anchors.fill: parent
+                    source: root.currentNumber > 0 && root.api ? root.api.imageUrl(root.currentNumber) : ""
+                    fillMode: Image.PreserveAspectFit
+                    asynchronous: true
+                }
+
+                Rectangle {
+                    anchors.top: parent.top
+                    anchors.right: parent.right
+                    anchors.margins: 10
+                    width: 34; height: 34; radius: 17
+                    color: Qt.rgba(0.05, 0.05, 0.07, 0.6)
+                    border.color: root.isFavorite ? theme.red : theme.line
+                    border.width: 1
+
+                    Label {
+                        anchors.centerIn: parent
+                        text: root.isFavorite ? "♥" : "♡"
+                        color: root.isFavorite ? theme.red : theme.textDim
+                        font.pixelSize: 16
+                    }
+                    MouseArea {
+                        anchors.fill: parent
+                        onClicked: root.currentNumber > 0 && root.toggleFavorite(root.currentNumber)
+                    }
+                }
+
+                Rectangle {
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.bottom: parent.bottom
+                    height: 56
+                    gradient: Gradient {
+                        GradientStop { position: 0.0; color: Qt.rgba(0.05, 0.05, 0.07, 0.92) }
+                        GradientStop { position: 1.0; color: "transparent" }
+                    }
+
+                    ColumnLayout {
+                        anchors.left: parent.left
+                        anchors.bottom: parent.bottom
+                        anchors.margins: 12
+                        spacing: 1
+                        Label {
+                            text: root.currentNumber > 0 ? ("#" + root.currentNumber) : ""
+                            color: theme.textFaint
+                            font.family: theme.fontMono
+                            font.pixelSize: 10
+                        }
+                        Label {
+                            text: root.currentStrip ? root.currentStrip.title : ""
+                            color: theme.text
+                            font.family: theme.fontDisplay
+                            font.pixelSize: 15
+                            font.bold: true
+                        }
+                    }
+                }
+            }
+
+            ToolButton {
+                text: "›"
+                enabled: root.currentIndex >= 0 && root.currentIndex < root.filteredStrips.length - 1
+                onClicked: root.goTo(1)
+                contentItem: Label { text: "›"; color: theme.text; font.pixelSize: 18; horizontalAlignment: Text.AlignHCenter }
+            }
+        }
+    }
+}

--- a/qml/Theme.qml
+++ b/qml/Theme.qml
@@ -1,0 +1,24 @@
+import QtQuick
+
+// Color/type tokens shared by every screen, matching the mockup reviewed
+// with the user before this was built. Instantiated per-file (no qmldir
+// singleton registration — see Api.qml's doc comment on staying
+// dependency-free) since it only ever holds constants.
+QtObject {
+    readonly property color ink: "#121319"
+    readonly property color panel: "#1a1c26"
+    readonly property color panelRaised: "#232634"
+    readonly property color panelSunken: "#0d0e13"
+    readonly property color line: "#34384a"
+    readonly property color lineSoft: "#262a38"
+    readonly property color text: "#eef0f6"
+    readonly property color textDim: "#9297ab"
+    readonly property color textFaint: "#62667a"
+    readonly property color teal: "#5eead4"
+    readonly property color tealDim: "#2c554e"
+    readonly property color red: "#ff5470"
+
+    readonly property string fontDisplay: "Sans Serif"
+    readonly property string fontBody: "Sans Serif"
+    readonly property string fontMono: "Monospace"
+}

--- a/qml/i18n/ar.json
+++ b/qml/i18n/ar.json
@@ -1,0 +1,38 @@
+{
+    "app": {
+        "navHome": "الرئيسية",
+        "navReader": "القارئ",
+        "navGallery": "المعرض",
+        "navRants": "المقالات",
+        "statusBackfilling": "المزامنة الأولية…",
+        "statusUpToDate": "محدّث"
+    },
+    "dashboard": {
+        "title": "الرئيسية",
+        "searchPlaceholder": "ابحث عن شريط (العنوان أو الرقم)",
+        "lastStripLabel": "أحدث شريط",
+        "resumeReading": "متابعة القراءة",
+        "lastRantLabel": "أحدث مقالة",
+        "readPost": "قراءة المقالة",
+        "statsStrips": "أشرطة مخزنة",
+        "statsFavorites": "المفضلة",
+        "statsRants": "مقالات"
+    },
+    "reader": {
+        "title": "القارئ",
+        "segAll": "كل الأشرطة",
+        "segMain": "القصة الرئيسية",
+        "jumpFavorites": "★ المفضلة",
+        "jumpChapter": "الفصل",
+        "jumpBonus": "إضافي"
+    },
+    "gallery": {
+        "title": "المعرض",
+        "chipAll": "الكل",
+        "chipFavorites": "★ المفضلة"
+    },
+    "rants": {
+        "title": "المقالات",
+        "loadingTranslation": "جارٍ الترجمة…"
+    }
+}

--- a/qml/i18n/de.json
+++ b/qml/i18n/de.json
@@ -1,0 +1,38 @@
+{
+    "app": {
+        "navHome": "Start",
+        "navReader": "Leser",
+        "navGallery": "Galerie",
+        "navRants": "Rants",
+        "statusBackfilling": "Erstsynchronisierung…",
+        "statusUpToDate": "Aktuell"
+    },
+    "dashboard": {
+        "title": "Start",
+        "searchPlaceholder": "Comic suchen (Titel oder Nummer)",
+        "lastStripLabel": "NEUESTER COMIC",
+        "resumeReading": "Lesen fortsetzen",
+        "lastRantLabel": "NEUESTER RANT",
+        "readPost": "Beitrag lesen",
+        "statsStrips": "zwischengespeicherte Comics",
+        "statsFavorites": "Favoriten",
+        "statsRants": "Rants"
+    },
+    "reader": {
+        "title": "Leser",
+        "segAll": "Alle Comics",
+        "segMain": "Haupthandlung",
+        "jumpFavorites": "★ Favoriten",
+        "jumpChapter": "Kapitel",
+        "jumpBonus": "Bonus"
+    },
+    "gallery": {
+        "title": "Galerie",
+        "chipAll": "Alle",
+        "chipFavorites": "★ Favoriten"
+    },
+    "rants": {
+        "title": "Rants",
+        "loadingTranslation": "Übersetzung läuft…"
+    }
+}

--- a/qml/i18n/en.json
+++ b/qml/i18n/en.json
@@ -1,0 +1,38 @@
+{
+    "app": {
+        "navHome": "Home",
+        "navReader": "Reader",
+        "navGallery": "Gallery",
+        "navRants": "Rants",
+        "statusBackfilling": "Initial sync…",
+        "statusUpToDate": "Up to date"
+    },
+    "dashboard": {
+        "title": "Home",
+        "searchPlaceholder": "Search a strip (title or number)",
+        "lastStripLabel": "LATEST STRIP",
+        "resumeReading": "Resume reading",
+        "lastRantLabel": "LATEST RANT",
+        "readPost": "Read post",
+        "statsStrips": "cached strips",
+        "statsFavorites": "favorites",
+        "statsRants": "rants"
+    },
+    "reader": {
+        "title": "Reader",
+        "segAll": "All strips",
+        "segMain": "Main story",
+        "jumpFavorites": "★ Favorites",
+        "jumpChapter": "Chapter",
+        "jumpBonus": "Bonus"
+    },
+    "gallery": {
+        "title": "Gallery",
+        "chipAll": "All",
+        "chipFavorites": "★ Favorites"
+    },
+    "rants": {
+        "title": "Rants",
+        "loadingTranslation": "Translating…"
+    }
+}

--- a/qml/i18n/es.json
+++ b/qml/i18n/es.json
@@ -1,0 +1,38 @@
+{
+    "app": {
+        "navHome": "Inicio",
+        "navReader": "Lector",
+        "navGallery": "Galería",
+        "navRants": "Rants",
+        "statusBackfilling": "Sincronización inicial…",
+        "statusUpToDate": "Actualizado"
+    },
+    "dashboard": {
+        "title": "Inicio",
+        "searchPlaceholder": "Buscar una tira (título o número)",
+        "lastStripLabel": "ÚLTIMA TIRA",
+        "resumeReading": "Reanudar lectura",
+        "lastRantLabel": "ÚLTIMO RANT",
+        "readPost": "Leer la entrada",
+        "statsStrips": "tiras en caché",
+        "statsFavorites": "favoritos",
+        "statsRants": "rants"
+    },
+    "reader": {
+        "title": "Lector",
+        "segAll": "Todas las tiras",
+        "segMain": "Historia principal",
+        "jumpFavorites": "★ Favoritos",
+        "jumpChapter": "Capítulo",
+        "jumpBonus": "Bonus"
+    },
+    "gallery": {
+        "title": "Galería",
+        "chipAll": "Todas",
+        "chipFavorites": "★ Favoritos"
+    },
+    "rants": {
+        "title": "Rants",
+        "loadingTranslation": "Traduciendo…"
+    }
+}

--- a/qml/i18n/fr.json
+++ b/qml/i18n/fr.json
@@ -1,0 +1,38 @@
+{
+    "app": {
+        "navHome": "Accueil",
+        "navReader": "Lecture",
+        "navGallery": "Galerie",
+        "navRants": "Rants",
+        "statusBackfilling": "Synchronisation initiale…",
+        "statusUpToDate": "À jour"
+    },
+    "dashboard": {
+        "title": "Accueil",
+        "searchPlaceholder": "Rechercher une planche (titre ou numéro)",
+        "lastStripLabel": "DERNIÈRE PLANCHE",
+        "resumeReading": "Reprendre la lecture",
+        "lastRantLabel": "DERNIER RANT",
+        "readPost": "Lire le billet",
+        "statsStrips": "planches en cache",
+        "statsFavorites": "favoris",
+        "statsRants": "rants"
+    },
+    "reader": {
+        "title": "Lecture",
+        "segAll": "Toutes les planches",
+        "segMain": "Histoire principale",
+        "jumpFavorites": "★ Favoris",
+        "jumpChapter": "Chapitre",
+        "jumpBonus": "Bonus"
+    },
+    "gallery": {
+        "title": "Galerie",
+        "chipAll": "Toutes",
+        "chipFavorites": "★ Favoris"
+    },
+    "rants": {
+        "title": "Rants",
+        "loadingTranslation": "Traduction en cours…"
+    }
+}

--- a/qml/i18n/hi.json
+++ b/qml/i18n/hi.json
@@ -1,0 +1,38 @@
+{
+    "app": {
+        "navHome": "होम",
+        "navReader": "रीडर",
+        "navGallery": "गैलरी",
+        "navRants": "रैंट्स",
+        "statusBackfilling": "प्रारंभिक सिंक हो रहा है…",
+        "statusUpToDate": "अद्यतन"
+    },
+    "dashboard": {
+        "title": "होम",
+        "searchPlaceholder": "स्ट्रिप खोजें (शीर्षक या नंबर)",
+        "lastStripLabel": "नवीनतम स्ट्रिप",
+        "resumeReading": "पढ़ना जारी रखें",
+        "lastRantLabel": "नवीनतम रैंट",
+        "readPost": "पोस्ट पढ़ें",
+        "statsStrips": "कैश की गई स्ट्रिप्स",
+        "statsFavorites": "पसंदीदा",
+        "statsRants": "रैंट्स"
+    },
+    "reader": {
+        "title": "रीडर",
+        "segAll": "सभी स्ट्रिप्स",
+        "segMain": "मुख्य कहानी",
+        "jumpFavorites": "★ पसंदीदा",
+        "jumpChapter": "अध्याय",
+        "jumpBonus": "बोनस"
+    },
+    "gallery": {
+        "title": "गैलरी",
+        "chipAll": "सभी",
+        "chipFavorites": "★ पसंदीदा"
+    },
+    "rants": {
+        "title": "रैंट्स",
+        "loadingTranslation": "अनुवाद हो रहा है…"
+    }
+}

--- a/qml/i18n/ja.json
+++ b/qml/i18n/ja.json
@@ -1,0 +1,38 @@
+{
+    "app": {
+        "navHome": "ホーム",
+        "navReader": "リーダー",
+        "navGallery": "ギャラリー",
+        "navRants": "ラント",
+        "statusBackfilling": "初回同期中…",
+        "statusUpToDate": "最新"
+    },
+    "dashboard": {
+        "title": "ホーム",
+        "searchPlaceholder": "ストリップを検索(タイトルまたは番号)",
+        "lastStripLabel": "最新のストリップ",
+        "resumeReading": "続きを読む",
+        "lastRantLabel": "最新のラント",
+        "readPost": "投稿を読む",
+        "statsStrips": "キャッシュ済みストリップ",
+        "statsFavorites": "お気に入り",
+        "statsRants": "ラント"
+    },
+    "reader": {
+        "title": "リーダー",
+        "segAll": "すべてのストリップ",
+        "segMain": "本編のみ",
+        "jumpFavorites": "★ お気に入り",
+        "jumpChapter": "第",
+        "jumpBonus": "ボーナス"
+    },
+    "gallery": {
+        "title": "ギャラリー",
+        "chipAll": "すべて",
+        "chipFavorites": "★ お気に入り"
+    },
+    "rants": {
+        "title": "ラント",
+        "loadingTranslation": "翻訳中…"
+    }
+}

--- a/qml/i18n/pt.json
+++ b/qml/i18n/pt.json
@@ -1,0 +1,38 @@
+{
+    "app": {
+        "navHome": "Início",
+        "navReader": "Leitor",
+        "navGallery": "Galeria",
+        "navRants": "Rants",
+        "statusBackfilling": "Sincronização inicial…",
+        "statusUpToDate": "Atualizado"
+    },
+    "dashboard": {
+        "title": "Início",
+        "searchPlaceholder": "Pesquisar uma tira (título ou número)",
+        "lastStripLabel": "ÚLTIMA TIRA",
+        "resumeReading": "Retomar leitura",
+        "lastRantLabel": "ÚLTIMO RANT",
+        "readPost": "Ler publicação",
+        "statsStrips": "tiras em cache",
+        "statsFavorites": "favoritos",
+        "statsRants": "rants"
+    },
+    "reader": {
+        "title": "Leitor",
+        "segAll": "Todas as tiras",
+        "segMain": "História principal",
+        "jumpFavorites": "★ Favoritos",
+        "jumpChapter": "Capítulo",
+        "jumpBonus": "Bônus"
+    },
+    "gallery": {
+        "title": "Galeria",
+        "chipAll": "Todas",
+        "chipFavorites": "★ Favoritos"
+    },
+    "rants": {
+        "title": "Rants",
+        "loadingTranslation": "Traduzindo…"
+    }
+}

--- a/qml/i18n/ru.json
+++ b/qml/i18n/ru.json
@@ -1,0 +1,38 @@
+{
+    "app": {
+        "navHome": "Главная",
+        "navReader": "Чтение",
+        "navGallery": "Галерея",
+        "navRants": "Рассказы",
+        "statusBackfilling": "Первичная синхронизация…",
+        "statusUpToDate": "Актуально"
+    },
+    "dashboard": {
+        "title": "Главная",
+        "searchPlaceholder": "Поиск выпуска (по названию или номеру)",
+        "lastStripLabel": "ПОСЛЕДНИЙ ВЫПУСК",
+        "resumeReading": "Продолжить чтение",
+        "lastRantLabel": "ПОСЛЕДНЯЯ ЗАПИСЬ",
+        "readPost": "Читать запись",
+        "statsStrips": "выпусков в кэше",
+        "statsFavorites": "избранных",
+        "statsRants": "записей"
+    },
+    "reader": {
+        "title": "Чтение",
+        "segAll": "Все выпуски",
+        "segMain": "Основная история",
+        "jumpFavorites": "★ Избранное",
+        "jumpChapter": "Глава",
+        "jumpBonus": "Бонус"
+    },
+    "gallery": {
+        "title": "Галерея",
+        "chipAll": "Все",
+        "chipFavorites": "★ Избранное"
+    },
+    "rants": {
+        "title": "Рассказы",
+        "loadingTranslation": "Перевод…"
+    }
+}

--- a/qml/i18n/zh.json
+++ b/qml/i18n/zh.json
@@ -1,0 +1,38 @@
+{
+    "app": {
+        "navHome": "主页",
+        "navReader": "阅读",
+        "navGallery": "画廊",
+        "navRants": "闲谈",
+        "statusBackfilling": "首次同步中…",
+        "statusUpToDate": "已是最新"
+    },
+    "dashboard": {
+        "title": "主页",
+        "searchPlaceholder": "搜索漫画(标题或编号)",
+        "lastStripLabel": "最新漫画",
+        "resumeReading": "继续阅读",
+        "lastRantLabel": "最新闲谈",
+        "readPost": "阅读文章",
+        "statsStrips": "已缓存漫画",
+        "statsFavorites": "收藏",
+        "statsRants": "闲谈"
+    },
+    "reader": {
+        "title": "阅读",
+        "segAll": "全部漫画",
+        "segMain": "主线剧情",
+        "jumpFavorites": "★ 收藏",
+        "jumpChapter": "第",
+        "jumpBonus": "番外"
+    },
+    "gallery": {
+        "title": "画廊",
+        "chipAll": "全部",
+        "chipFavorites": "★ 收藏"
+    },
+    "rants": {
+        "title": "闲谈",
+        "loadingTranslation": "翻译中…"
+    }
+}

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -2,78 +2,191 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 
-// Minimal placeholder: proves the launcher -> qml6 -> daemon API pipeline
-// end to end (spawn, arguments, XHR, auth header). The real screens
-// (strip gallery, rant reader with translation, settings) are tracked
-// separately — see the project's open issues.
+// Shell: sidebar nav + the four screens reviewed with the user before this
+// was built (Home/Reader/Gallery/Rants — Settings' remote-config
+// persistence is a separate follow-up, see the project's issues). QML talks
+// to the daemon directly over its HTTP API (local or remote, see
+// gui::daemon_link), so there's nothing here for a local control server to
+// answer — base_url/token just come in as positional arguments from
+// gui::launcher.
 ApplicationWindow {
     id: window
     visible: true
-    width: 480
-    height: 360
+    width: 1180
+    height: 760
+    minimumWidth: 720
+    minimumHeight: 480
     title: "Megatokyo"
 
-    // Passed positionally after `--` by gui/src/launcher.rs, since QML
-    // doesn't reliably read process environment variables.
     property string baseUrl: Qt.application.arguments.length > 1 ? Qt.application.arguments[Qt.application.arguments.length - 2] : ""
     property string apiToken: Qt.application.arguments.length > 1 ? Qt.application.arguments[Qt.application.arguments.length - 1] : ""
 
-    property string statusText: "Connecting…"
-    property int chapterCount: 0
+    property var chapters: []
+    property var strips: []
+    property var rants: []
+    property var favorites: []
+    property var status: ({})
+    property int progressStrip: -1
 
-    function refresh() {
-        var statusRequest = new XMLHttpRequest()
-        statusRequest.open("GET", baseUrl + "/status")
-        statusRequest.setRequestHeader("x-megatokyo-daemon-token", apiToken)
-        statusRequest.onreadystatechange = function () {
-            if (statusRequest.readyState !== XMLHttpRequest.DONE)
-                return
-            if (statusRequest.status === 200) {
-                var status = JSON.parse(statusRequest.responseText)
-                statusText = status.backfilling
-                    ? "Backfilling…"
-                    : "Last strip #" + status.last_strip_number + ", last rant #" + status.last_rant_number
-            } else {
-                statusText = "Could not reach the daemon at " + baseUrl + " (HTTP " + statusRequest.status + ")"
-            }
-        }
-        statusRequest.send()
+    readonly property var theme: Theme {}
 
-        var chaptersRequest = new XMLHttpRequest()
-        chaptersRequest.open("GET", baseUrl + "/chapters")
-        chaptersRequest.setRequestHeader("x-megatokyo-daemon-token", apiToken)
-        chaptersRequest.onreadystatechange = function () {
-            if (chaptersRequest.readyState !== XMLHttpRequest.DONE)
-                return
-            if (chaptersRequest.status === 200)
-                chapterCount = JSON.parse(chaptersRequest.responseText).length
-        }
-        chaptersRequest.send()
+    Api {
+        id: api
+        baseUrl: window.baseUrl
+        token: window.apiToken
     }
 
-    Component.onCompleted: refresh()
+    function refreshChapters() {
+        api.get("/chapters", function (body) { window.chapters = body || [] })
+    }
+    function refreshStrips() {
+        api.get("/strips", function (body) { window.strips = body || [] })
+    }
+    function refreshRants() {
+        api.get("/rants", function (body) { window.rants = body || [] })
+    }
+    function refreshFavorites() {
+        api.get("/favorites", function (body) { window.favorites = body || [] })
+    }
+    function refreshStatus() {
+        api.get("/status", function (body) { window.status = body || {} })
+    }
+    function refreshProgress() {
+        api.get("/progress", function (body) {
+            window.progressStrip = body && body.strip_number ? body.strip_number : -1
+        })
+    }
+    function refreshAll() {
+        refreshChapters()
+        refreshStrips()
+        refreshRants()
+        refreshFavorites()
+        refreshStatus()
+        refreshProgress()
+    }
 
-    ColumnLayout {
-        anchors.centerIn: parent
-        spacing: 12
+    function isFavorite(number) {
+        return window.favorites.some(function (f) { return f.strip_number === number })
+    }
 
-        Label {
-            text: "Megatokyo"
-            font.pointSize: 20
-            Layout.alignment: Qt.AlignHCenter
+    function toggleFavorite(number) {
+        if (isFavorite(number))
+            api.del("/favorites?number=" + number, refreshFavorites)
+        else
+            api.post("/favorites?number=" + number, refreshFavorites)
+    }
+
+    function saveProgress(number) {
+        window.progressStrip = number
+        api.post("/progress?number=" + number)
+    }
+
+    function openReader(number) {
+        readerScreen.currentNumber = number
+        nav.currentIndex = 1
+    }
+
+    function openRant(number) {
+        rantsScreen.selectedNumber = number
+        nav.currentIndex = 3
+    }
+
+    Component.onCompleted: refreshAll()
+
+    background: Rectangle { color: theme.ink }
+
+    RowLayout {
+        anchors.fill: parent
+        spacing: 0
+
+        // -- sidebar ------------------------------------------------------
+        Rectangle {
+            Layout.preferredWidth: 208
+            Layout.fillHeight: true
+            color: theme.panelSunken
+
+            ColumnLayout {
+                anchors.fill: parent
+                anchors.margins: 12
+                spacing: 2
+
+                Repeater {
+                    id: nav
+                    property int currentIndex: 0
+                    model: [I18n.tr("app.navHome"), I18n.tr("app.navReader"), I18n.tr("app.navGallery"), I18n.tr("app.navRants")]
+                    delegate: Rectangle {
+                        Layout.fillWidth: true
+                        height: 36
+                        radius: 9
+                        color: nav.currentIndex === index ? theme.tealDim : "transparent"
+
+                        Label {
+                            anchors.left: parent.left
+                            anchors.verticalCenter: parent.verticalCenter
+                            anchors.leftMargin: 12
+                            text: modelData
+                            font.pixelSize: 13
+                            color: nav.currentIndex === index ? theme.teal : theme.textDim
+                        }
+                        MouseArea {
+                            anchors.fill: parent
+                            onClicked: nav.currentIndex = index
+                        }
+                    }
+                }
+
+                Item { Layout.fillHeight: true }
+
+                Label {
+                    Layout.fillWidth: true
+                    text: I18n.tr(window.status.backfilling ? "app.statusBackfilling" : "app.statusUpToDate")
+                    font.family: theme.fontMono
+                    font.pixelSize: 10
+                    color: window.status.backfilling ? theme.textDim : theme.teal
+                    elide: Text.ElideRight
+                }
+            }
         }
-        Label {
-            text: statusText
-            Layout.alignment: Qt.AlignHCenter
-        }
-        Label {
-            text: chapterCount + " chapters known"
-            Layout.alignment: Qt.AlignHCenter
-        }
-        Button {
-            text: "Refresh"
-            Layout.alignment: Qt.AlignHCenter
-            onClicked: refresh()
+
+        // -- content --------------------------------------------------------
+        StackLayout {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            currentIndex: nav.currentIndex
+
+            DashboardScreen {
+                api: api
+                strips: window.strips
+                rants: window.rants
+                favorites: window.favorites
+                progressStrip: window.progressStrip
+                openReader: window.openReader
+                openRant: window.openRant
+            }
+
+            ReaderScreen {
+                id: readerScreen
+                api: api
+                strips: window.strips
+                chapters: window.chapters
+                favorites: window.favorites
+                toggleFavorite: window.toggleFavorite
+                saveProgress: window.saveProgress
+            }
+
+            GalleryScreen {
+                api: api
+                strips: window.strips
+                chapters: window.chapters
+                favorites: window.favorites
+                openReader: window.openReader
+            }
+
+            RantsScreen {
+                id: rantsScreen
+                api: api
+                rants: window.rants
+            }
         }
     }
 }

--- a/qml/qmldir
+++ b/qml/qmldir
@@ -1,0 +1,1 @@
+singleton I18n 1.0 I18n.qml


### PR DESCRIPTION
## Summary
- Replaces the placeholder `main.qml` with the four screens reviewed with the user beforehand (mockup discussed in chat): Home, Reader, Gallery, Rants — each wired to the real daemon API (chapters/strips/rants, favorites, reading progress, per-language rant translation).
- `daemon`: `/image` now also accepts the token as a `?token=` query param, since QML's `Image` element can't set custom request headers (signed-URL style, scoped to just that one route).
- `gui`: launcher now sets `QML_XHR_ALLOW_FILE_READ=1` so `I18n.qml` can load its local JSON dictionaries.
- `qml`: `Api.qml` (XHR wrapper), `Theme.qml` (shared color/type tokens), `I18n.qml` — ported from `linux_hello_config`'s own `I18n.qml`, same 10-language (en/fr/es/de/ru/ja/zh/ar/hi/pt) JSON-dictionary pattern — plus the four screens themselves.
- Settings screen is split out to #11: persisting it from QML needs a small write-back mechanism that doesn't exist yet, so it's out of scope here to keep this PR focused.

## Verification
- [x] `cargo build/test/clippy/fmt` all pass
- [x] `qmllint` on every `.qml` file — no errors (only style-level "unqualified access" warnings)
- [x] Offscreen smoke test: `qml6` run directly with `QT_QPA_PLATFORM=offscreen` against a locally-backfilled daemon (real megatokyo.com data) — no runtime QML errors, screens loaded live chapters/strips/rants over the API
- [ ] Visual check of actual rendering — left to the user, per their stated preference (I don't take screenshots of or otherwise interact with the real desktop for this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)