### PR TITLE
Add Launchpad PPA publishing

### DIFF
--- a/.github/workflows/publish-ppa.yml
+++ b/.github/workflows/publish-ppa.yml
@@ -1,0 +1,96 @@
+name: Publish to Launchpad PPA
+
+# Automatically uploads a source package to ppa:aarklendoia-edtech/megatokyo
+# on every vX.Y.Z release tag (same trigger as build-debian.yml's GitHub
+# Release build). See docs/LAUNCHPAD.md for the full manual process this
+# automates, and for how the ~ppa1~<series>1 versioning scheme works.
+#
+# Signs with a CI-only GPG key, registered as an additional OpenPGP key on
+# the aarklendoia-edtech Launchpad account — deliberately separate from the
+# maintainer's personal key (and from linux-hello's/kio-protondrive's own CI
+# keys), so a leaked CI secret only compromises this package's PPA-upload
+# rights. The private key has no passphrase (required for unattended
+# signing); it's stored only as the PPA_GPG_PRIVATE_KEY repository secret.
+
+on:
+  push:
+    tags: [ 'v*' ]
+  workflow_dispatch:
+    inputs:
+      series:
+        description: 'Target Ubuntu series codename'
+        required: true
+        default: 'resolute'
+      rust_toolchain:
+        description: "That series' packaged cargo/rustc version (rmadison -u ubuntu cargo)"
+        required: true
+        default: '1.93.1'
+
+env:
+  PPA: 'ppa:aarklendoia-edtech/megatokyo'
+  GPG_KEY_ID: '463A3894A7CAC3F707B93B2E37C96955509787D3'
+  DEBFULLNAME: 'megatokyo CI'
+  DEBEMAIL: 'aarklendoia+ci@proton.me'
+  SERIES: ${{ github.event.inputs.series || 'resolute' }}
+  RUST_TOOLCHAIN: ${{ github.event.inputs.rust_toolchain || '1.93.1' }}
+
+jobs:
+  publish-ppa:
+    runs-on: ubuntu-latest
+    # See kio-protondrive's own publish-ppa.yml: a stuck apt-get on a
+    # non-containerized runner can hang the full 6h GitHub Actions default
+    # and silently never publish. Keep this short so a repeat fails fast
+    # and visibly instead.
+    timeout-minutes: 30
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Install packaging tools
+        # No project build-dependencies needed here (qt6-base-dev, ...) —
+        # debuild -S only tars the source, it doesn't compile anything, and
+        # cargo vendor doesn't run build scripts either.
+        env:
+          DEBIAN_FRONTEND: noninteractive
+          NEEDRESTART_MODE: a
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y devscripts dpkg-dev debhelper fakeroot quilt dput lintian gnupg jq
+
+      - name: Install Rust matching ${{ env.SERIES }}'s packaged toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+
+      - name: Import the CI signing key
+        env:
+          PPA_GPG_PRIVATE_KEY: ${{ secrets.PPA_GPG_PRIVATE_KEY }}
+        run: |
+          echo "$PPA_GPG_PRIVATE_KEY" | gpg --batch --import
+          gpg --list-secret-keys "$GPG_KEY_ID"
+
+      - name: Vendor Cargo dependencies
+        run: |
+          RUST_TOOLCHAIN="${{ env.RUST_TOOLCHAIN }}" ./debian/scripts/prepare-offline-build.sh
+
+      - name: Bump changelog for this PPA upload
+        env:
+          IS_TAG: ${{ github.ref_type == 'tag' }}
+        run: |
+          if [ "$IS_TAG" = "true" ]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          else
+            # workflow_dispatch on a branch: no vX.Y.Z tag to derive from
+            VERSION="$(grep -m1 '^version' Cargo.toml | sed -E 's/.*"(.+)"/\1/')"
+          fi
+          dch --newversion "${VERSION}~ppa1~${SERIES}1" --distribution "$SERIES" --urgency medium \
+            "Automated PPA build for ${SERIES}, release ${VERSION}."
+
+      - name: Build signed source package
+        run: |
+          rm -rf target
+          debuild -S -sa -d -k"$GPG_KEY_ID"
+
+      - name: Upload to the PPA
+        run: |
+          dput "$PPA" ../megatokyo_*_source.changes

--- a/debian/rules
+++ b/debian/rules
@@ -16,8 +16,28 @@ override_dh_auto_clean:
 	# In CI, the target directory is absent anyway (clean clone).
 	true
 
+override_dh_clean:
+	# dh_clean's default cruft-removal (part of every `debian/rules clean`,
+	# which dpkg-buildpackage always runs before building — including on
+	# the Launchpad builder itself, unconditionally) deletes any *.orig
+	# file anywhere in the tree, meant for stray patch-reject leftovers.
+	# It doesn't know vendor/*/Cargo.toml.orig are files cargo actually
+	# needs at build time to verify a vendored crate's checksum — without
+	# this exclude, they get wiped right before override_dh_auto_build
+	# runs, even though they were present in the uploaded source tarball.
+	dh_clean -Xvendor
+
 override_dh_auto_build:
-	cargo build --release --workspace --verbose
+	# If vendor/ + .cargo/config.toml are present (see
+	# debian/scripts/prepare-offline-build.sh), build fully offline — this
+	# is what a Launchpad PPA build needs, since its builders have no
+	# general internet access to reach crates.io. Otherwise (GitHub
+	# Actions, local dev), fall back to the normal networked build.
+	if [ -d $(CURDIR)/vendor ] && [ -f $(CURDIR)/.cargo/config.toml ]; then \
+		cargo build --release --workspace --verbose --offline; \
+	else \
+		cargo build --release --workspace --verbose; \
+	fi
 
 override_dh_auto_test:
 	# Every test in this workspace is either fixture-based (scraper, feed)
@@ -25,7 +45,11 @@ override_dh_auto_test:
 	# megatokyo.com/DeepL) — see core/src/*.rs's test modules — so this is
 	# safe to run in a network-less build environment (Launchpad PPA
 	# builders included).
-	cargo test --release --workspace --verbose
+	if [ -d $(CURDIR)/vendor ] && [ -f $(CURDIR)/.cargo/config.toml ]; then \
+		cargo test --release --workspace --verbose --offline; \
+	else \
+		cargo test --release --workspace --verbose; \
+	fi
 
 override_dh_auto_install:
 	mkdir -p $(CURDIR)/debian/tmp/usr/bin
@@ -50,4 +74,4 @@ override_dh_install:
 override_dh_missing:
 	dh_missing --list-missing
 
-.PHONY: override_dh_auto_build override_dh_auto_test override_dh_auto_install override_dh_install
+.PHONY: override_dh_auto_clean override_dh_clean override_dh_auto_build override_dh_auto_test override_dh_auto_install override_dh_install override_dh_missing

--- a/debian/scripts/prepare-offline-build.sh
+++ b/debian/scripts/prepare-offline-build.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Run this locally, with network access, before building a Launchpad source
+# upload (debuild -S -sa). NEVER run as part of debian/rules — Launchpad's
+# build farm has no general internet access, so everything this script
+# fetches must already be sitting in the working directory by the time
+# dpkg-source tars it up.
+#
+# Unlike linux-hello/kio-protondrive, this workspace is pure Cargo (no
+# CMake/Corrosion, no build.rs downloading model files) so there is exactly
+# one thing to vendor: crates.io dependencies.
+#
+# IMPORTANT: vendor with the SAME cargo version the target Ubuntu series
+# ships (check with `rmadison -u ubuntu cargo`), not whatever's locally
+# "stable" — a newer cargo vendoring the tree can silently omit
+# Cargo.toml.orig companion files an OLDER cargo needs at build time to
+# verify a vendored crate's checksum against Cargo.lock (hit for real on
+# linux-hello, see its own copy of this script). Set RUST_TOOLCHAIN to the
+# version to vendor with; defaults to "stable", which is very likely wrong
+# for an older LTS target — pass the real one explicitly:
+#   RUST_TOOLCHAIN=1.93.1 ./debian/scripts/prepare-offline-build.sh
+#
+# See docs/LAUNCHPAD.md for how this fits into the release process.
+
+set -eu
+
+RUST_TOOLCHAIN="${RUST_TOOLCHAIN:-stable}"
+
+cd "$(dirname "$0")/../.."
+
+echo "==> Removing target/ (must not exist when dpkg-source tars up the tree)"
+rm -rf target
+
+echo "==> Vendoring Cargo dependencies into vendor/ (toolchain: $RUST_TOOLCHAIN)"
+if [ "$RUST_TOOLCHAIN" = "stable" ]; then
+  echo "    WARNING: no RUST_TOOLCHAIN given, using 'stable' — check the target" >&2
+  echo "    series' cargo version first (rmadison -u ubuntu cargo) and pass" >&2
+  echo "    RUST_TOOLCHAIN=<version> explicitly if it differs." >&2
+fi
+rustup toolchain install "$RUST_TOOLCHAIN" > /dev/null 2>&1 || true
+rm -rf vendor .cargo
+cargo "+$RUST_TOOLCHAIN" vendor vendor > /tmp/cargo-vendor-config.toml.tmp
+mkdir -p .cargo
+cat /tmp/cargo-vendor-config.toml.tmp > .cargo/config.toml
+rm -f /tmp/cargo-vendor-config.toml.tmp
+echo "    $(du -sh vendor | cut -f1) in vendor/, $(find vendor -name '*.orig' | wc -l) .orig files"
+
+echo "==> Disabling cargo's per-file checksum verification for vendored crates"
+# dpkg-source's native-tarball builder has a hardcoded exclude list (VCS
+# control files, backup/swap files — .git, .gitignore, .svn, CVS, *.orig,
+# DEADJOE, ...) that cannot be turned off via debian/source/options. Some
+# vendored crate, somewhere, will always have a test fixture or metadata
+# file that happens to match one of those generic names — dpkg-source
+# silently drops it from the tarball, and cargo's offline build then fails
+# verifying that crate's per-file checksums against .cargo-checksum.json.
+# Documented Debian Rust-packaging fix: blank out each vendored crate's
+# "files" checksum map so cargo only trusts the vendor directory as-is (the
+# "package" checksum, verified against Cargo.lock, is untouched). Same fix
+# as linux-hello's and kio-protondrive's own copy of this script.
+find vendor -maxdepth 2 -name ".cargo-checksum.json" |
+  while IFS= read -r f; do
+    jq '.files = {}' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+  done
+
+cat <<EOF
+
+Ready. From this same working directory (with vendor/ and .cargo/config.toml
+populated), debian/rules will build with 'cargo build --offline'. Proceed
+with the dch / debuild -S -sa / dput cycle from docs/LAUNCHPAD.md.
+
+Nothing here is meant to be committed to git — vendor/ and .cargo/ are
+regenerated per release right before packaging (see .gitignore).
+EOF

--- a/docs/LAUNCHPAD.md
+++ b/docs/LAUNCHPAD.md
@@ -1,0 +1,112 @@
+# Publishing to Launchpad (PPA)
+
+Step-by-step guide to publish megatokyo as a Launchpad PPA
+(`ppa:aarklendoia-edtech/megatokyo`), so users can `apt install` it directly
+instead of downloading `.deb` files from GitHub Releases. This mirrors
+[linux-hello](https://github.com/Aarklendoia/linux-hello)'s and
+[kio-protondrive](https://github.com/Aarklendoia/kio-protondrive)'s process
+(see their own `docs/LAUNCHPAD.md`) — same Launchpad account, deliberately a
+**separate PPA** so the three unrelated projects don't share one archive.
+
+- Launchpad account: `aarklendoia-edtech` (already exists, reused from
+  linux-hello/kio-protondrive)
+- Personal signing key (manual uploads): reuse the existing
+  `86EB1CE672402B0B104049C3D4251A0893FE3895` (`aarklendoia@proton.me`),
+  already confirmed on the account with the Code of Conduct signed — no new
+  personal key needed.
+- CI signing key (automated uploads): generated and registered on the
+  `aarklendoia-edtech` account, fingerprint
+  `463A3894A7CAC3F707B93B2E37C96955509787D3` (`aarklendoia+ci@proton.me`,
+  UID `megatokyo CI`) — a new, project-specific key, deliberately not
+  reusing linux-hello's or kio-protondrive's CI key, so a leaked secret in
+  one repo's Actions only compromises that one PPA. RSA 4096, sign-only, no
+  passphrase (required for unattended CI signing), expires 2028-08-20.
+  Private key added as the `PPA_GPG_PRIVATE_KEY` repository secret.
+- PPA: `ppa:aarklendoia-edtech/megatokyo`
+  (<https://launchpad.net/~aarklendoia-edtech/+archive/ubuntu/megatokyo>)
+
+Launchpad's build farm has no general internet access, so the plain `cargo
+build --release` in `debian/rules` would fail there — see
+[Vendoring](#2-vendoring-required-before-every-ppa-upload) for how that's
+handled.
+
+## 1. One-time setup (manual, on launchpad.net)
+
+None of this can be automated from a script — it requires a browser and your
+Launchpad identity.
+
+1. Create the PPA: your Launchpad profile page
+   (`https://launchpad.net/~aarklendoia-edtech`) → "Create a new PPA" → name
+   it `megatokyo`, public visibility.
+2. Generate a new, dedicated CI signing key (don't reuse the other
+   projects'): done — `463A3894A7CAC3F707B93B2E37C96955509787D3`.
+3. On your Launchpad profile → "OpenPGP keys" → import the new fingerprint
+   as an *additional* key on the same `aarklendoia-edtech` account. Launchpad
+   emails a confirmation you must decrypt (`gpg --decrypt`) and follow the
+   link in, or `gpg --clearsign` the confirmation text it shows on the page
+   directly — done.
+4. Install the upload tooling locally, if not already present:
+
+   ```bash
+   sudo apt install devscripts dput debhelper lintian gnupg
+   ```
+
+5. Private key added as the `PPA_GPG_PRIVATE_KEY` GitHub Actions repository
+   secret — done:
+
+   ```bash
+   gpg --armor --export-secret-keys 463A3894A7CAC3F707B93B2E37C96955509787D3
+   # paste the output into the GitHub repo secret
+   ```
+
+## 2. Vendoring (required before every PPA upload)
+
+Launchpad's builders can't reach crates.io during a build. Unlike
+linux-hello/kio-protondrive, this workspace is pure Cargo (no
+CMake/Corrosion, no build.rs downloading model files), so there is exactly
+one thing to vendor:
+
+```bash
+# Check the target series' packaged cargo version first:
+rmadison -u ubuntu cargo | grep resolute
+
+RUST_TOOLCHAIN=1.93.1 ./debian/scripts/prepare-offline-build.sh
+```
+
+This vendors Cargo dependencies into `vendor/` (+ `.cargo/config.toml`) —
+see the script's comments for **why the toolchain version matters** (a
+newer local cargo can vendor a tree an older, series-packaged cargo can't
+verify — already hit and documented in linux-hello's equivalent script).
+`vendor/` and `.cargo/` are git-ignored: regenerated per release, not part
+of normal `main` history. Since `debian/source/format` is `3.0 (native)`,
+`debuild -S` tars up whatever is physically present at that moment,
+`.gitignore` notwithstanding.
+
+## 3. Building and uploading a release
+
+One **source-only** upload per target Ubuntu series:
+
+```bash
+dch --newversion "0.1.0~ppa1~resolute1" --distribution resolute --urgency medium \
+  "Automated PPA build for resolute, release 0.1.0."
+
+debuild -S -sa -k463A3894A7CAC3F707B93B2E37C96955509787D3
+
+dput ppa:aarklendoia-edtech/megatokyo ../megatokyo_0.1.0~ppa1~resolute1_source.changes
+```
+
+Track build status at
+`https://launchpad.net/~aarklendoia-edtech/+archive/ubuntu/megatokyo/+packages`.
+
+## 4. Automated publishing (CI)
+
+[.github/workflows/publish-ppa.yml](../.github/workflows/publish-ppa.yml)
+automates the cycle above on every `vX.Y.Z` release tag (same trigger as
+`build-debian.yml`), or manually via `workflow_dispatch`. Needs the PPA to
+exist (step 1 above) before it can succeed.
+
+## 5. Once published
+
+Add the `add-apt-repository ppa:aarklendoia-edtech/megatokyo` /
+`apt install megatokyo-daemon megatokyo-gui` instructions to the README's
+install section and a Launchpad badge to the badge row.


### PR DESCRIPTION
## Summary
- Vendoring script (`debian/scripts/prepare-offline-build.sh`) so `debuild -S` works on Launchpad's builders (no internet access) — pure `cargo vendor`, this workspace has no build.rs downloads unlike linux-hello/kio-protondrive.
- `debian/rules`: offline-build detection (mirrors linux-hello's), `dh_clean -Xvendor` to protect vendored `Cargo.toml.orig` files.
- `docs/LAUNCHPAD.md`: full one-time-setup + release process, same structure as the other two projects' docs.
- `.github/workflows/publish-ppa.yml`: automated PPA upload on `vX.Y.Z` tags, signs with a new dedicated CI key (fingerprint `463A3894A7CAC3F707B93B2E37C96955509787D3`, confirmed on the `aarklendoia-edtech` Launchpad account).

## Test plan
- [x] `make -f debian/rules -n` dry-run on the modified targets — no syntax errors
- [x] `sh -n` on the vendoring script
- [x] YAML validated
- [x] Create `ppa:aarklendoia-edtech/megatokyo` on Launchpad (manual, done outside this PR)
- [ ] First real `RUST_TOOLCHAIN=... ./debian/scripts/prepare-offline-build.sh` + `debuild -S -sa` + `dput` cycle, or a `workflow_dispatch` run of `publish-ppa.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)