### PR TITLE
fix(ci): grant contents:write for release asset uploads

### DIFF
--- a/.github/workflows/build-debian.yml
+++ b/.github/workflows/build-debian.yml
@@ -8,6 +8,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
The v0.2.0 run's "Create Release (on tag)" step failed with "Resource not accessible by integration" — `build-debian.yml` had no `permissions:` block, so the default `GITHUB_TOKEN` is read-only for `contents`. `release-please.yml` already sets `contents: write`; this brings `build-debian.yml` in line.

## Test plan
- [x] YAML validated
- [ ] CI passes on this PR
- [ ] Manually re-run the v0.2.0 workflow (or wait for the next tag) to confirm the release step succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)