### PR TITLE
feat: Settings screen (remote daemon config, DeepL key, notifications)

### DIFF
--- a/daemon/src/control.rs
+++ b/daemon/src/control.rs
@@ -7,6 +7,7 @@
 //! header to match [`AppState::token`].
 
 use std::net::SocketAddr;
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -19,13 +20,24 @@ use megatokyo_core::translate::{get_translated_rant, Translator};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 
+use crate::config::Config;
+
 const TOKEN_HEADER: &str = "x-megatokyo-daemon-token";
 
 pub struct AppState {
     pub store: Store,
     pub image_cache: ImageCache,
-    pub translator: Option<Translator>,
     pub token: String,
+    /// `deepl_api_key`/`poll_interval_minutes` are editable via `GET`/`POST
+    /// /config` (the Settings screen's "this daemon" section) — `bind` and
+    /// `api_token` are part of the same on-disk file but never touched by
+    /// that route, so nothing here bothers gating access to just those two
+    /// fields. A `Translator` is built fresh from `deepl_api_key` wherever
+    /// one is needed instead of being cached on `AppState`, so a key change
+    /// here takes effect on the very next translated-rant request with no
+    /// extra invalidation logic.
+    pub config: tokio::sync::RwLock<Config>,
+    pub config_path: PathBuf,
     /// Set while the initial archive backfill (or a `/check`-triggered
     /// cycle) is running — surfaced on `/status` so a client can tell "no
     /// content yet" apart from "still loading".
@@ -180,6 +192,7 @@ async fn route(req: &str, path: &str, state: &AppState) -> Response {
             state.check_requested.notify_one();
             Response::ok_json(&serde_json::json!({"ok": true}))
         }
+        "/config" => route_config(req, state).await,
         _ => Response::not_found(),
     }
 }
@@ -219,11 +232,17 @@ async fn route_rant(req: &str, state: &AppState) -> Response {
     let content = if lang.is_empty() || lang.eq_ignore_ascii_case("en") {
         rant.content.clone()
     } else {
-        let translated = match &state.translator {
-            Some(translator) => get_translated_rant(&state.store, translator, number, &lang)
+        // Built fresh from the current config rather than cached on
+        // AppState, so a key change via POST /config takes effect on the
+        // very next request — see AppState's own doc comment.
+        let deepl_api_key = state.config.read().await.deepl_api_key.clone();
+        let translated = if deepl_api_key.is_empty() {
+            Err("no DeepL API key configured".to_string())
+        } else {
+            let translator = Translator::new(deepl_api_key);
+            get_translated_rant(&state.store, &translator, number, &lang)
                 .await
-                .map_err(|e| e.to_string()),
-            None => Err("no DeepL API key configured".to_string()),
+                .map_err(|e| e.to_string())
         };
         match translated {
             // `rant` above already confirmed this number exists, so
@@ -343,17 +362,72 @@ fn route_progress(req: &str, state: &AppState) -> Response {
     }
 }
 
+/// `GET`/`POST` for the Settings screen's "this daemon" section —
+/// `deepl_api_key` and `poll_interval_minutes` only, see `AppState::config`'s
+/// doc comment for why `bind`/`api_token` are deliberately not reachable
+/// here. `POST` applies whichever query params are present (each field can
+/// be updated independently) and persists the full config back to disk
+/// immediately.
+async fn route_config(req: &str, state: &AppState) -> Response {
+    match request_method(req) {
+        "GET" => {
+            let config = state.config.read().await;
+            Response::ok_json(&serde_json::json!({
+                "deepl_api_key": config.deepl_api_key,
+                "poll_interval_minutes": config.poll_interval_minutes,
+            }))
+        }
+        "POST" => {
+            let mut config = state.config.write().await;
+            if let Some(key) = extract_query_param(req, "deepl_api_key") {
+                config.deepl_api_key = key;
+            }
+            if let Some(minutes) = extract_query_param(req, "poll_interval_minutes") {
+                match minutes.parse::<u64>() {
+                    Ok(m) if m > 0 => config.poll_interval_minutes = m,
+                    _ => {
+                        return Response::bad_request(
+                            "poll_interval_minutes must be a positive integer",
+                        )
+                    }
+                }
+            }
+            match config.save(&state.config_path) {
+                Ok(()) => Response::ok_json(&serde_json::json!({
+                    "deepl_api_key": config.deepl_api_key,
+                    "poll_interval_minutes": config.poll_interval_minutes,
+                })),
+                Err(err) => Response::server_error(&err.to_string()),
+            }
+        }
+        _ => Response::not_found(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use megatokyo_core::domain::{Chapter, Rant};
 
+    fn test_config() -> Config {
+        Config {
+            bind: "127.0.0.1:0".to_string(),
+            api_token: "test-token".to_string(),
+            deepl_api_key: String::new(),
+            poll_interval_minutes: 15,
+        }
+    }
+
+    /// Placeholder path: fine for every test except the ones exercising
+    /// `POST /config`'s persistence, which build their own `AppState` with a
+    /// real tempdir instead of using this shared helper.
     fn state() -> AppState {
         AppState {
             store: Store::open_in_memory().unwrap(),
             image_cache: ImageCache::new(std::env::temp_dir()),
-            translator: None,
             token: "test-token".to_string(),
+            config: tokio::sync::RwLock::new(test_config()),
+            config_path: std::env::temp_dir().join("megatokyo-test-unused-config.toml"),
             backfilling: AtomicBool::new(false),
             check_requested: tokio::sync::Notify::new(),
         }
@@ -530,5 +604,74 @@ mod tests {
         let state = state();
         let response = route("GET /nope HTTP/1.1\r\n", "/nope", &state).await;
         assert_eq!(response.status, "404 Not Found");
+    }
+
+    #[tokio::test]
+    async fn config_route_reports_the_current_settings() {
+        let state = state();
+        let response = route("GET /config HTTP/1.1\r\n", "/config", &state).await;
+        assert_eq!(response.status, "200 OK");
+        let body: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
+        assert_eq!(body["deepl_api_key"], "");
+        assert_eq!(body["poll_interval_minutes"], 15);
+    }
+
+    fn state_with_persisted_config(dir: &std::path::Path) -> AppState {
+        let config_path = dir.join("config.toml");
+        AppState {
+            store: Store::open_in_memory().unwrap(),
+            image_cache: ImageCache::new(std::env::temp_dir()),
+            token: "test-token".to_string(),
+            config: tokio::sync::RwLock::new(test_config()),
+            config_path,
+            backfilling: AtomicBool::new(false),
+            check_requested: tokio::sync::Notify::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn config_route_post_updates_only_the_given_fields_and_persists_them() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = state_with_persisted_config(dir.path());
+
+        let response = route(
+            "POST /config?deepl_api_key=secret-key HTTP/1.1\r\n",
+            "/config",
+            &state,
+        )
+        .await;
+        assert_eq!(response.status, "200 OK");
+        let body: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
+        assert_eq!(body["deepl_api_key"], "secret-key");
+        // Untouched by this call, still whatever it was before.
+        assert_eq!(body["poll_interval_minutes"], 15);
+
+        let saved = std::fs::read_to_string(&state.config_path).unwrap();
+        assert!(saved.contains("secret-key"));
+
+        let response = route(
+            "POST /config?poll_interval_minutes=30 HTTP/1.1\r\n",
+            "/config",
+            &state,
+        )
+        .await;
+        let body: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
+        // The key set by the previous call is still there — a partial
+        // update never clobbers fields it wasn't given.
+        assert_eq!(body["deepl_api_key"], "secret-key");
+        assert_eq!(body["poll_interval_minutes"], 30);
+    }
+
+    #[tokio::test]
+    async fn config_route_post_rejects_a_non_positive_poll_interval() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = state_with_persisted_config(dir.path());
+        let response = route(
+            "POST /config?poll_interval_minutes=0 HTTP/1.1\r\n",
+            "/config",
+            &state,
+        )
+        .await;
+        assert_eq!(response.status, "400 Bad Request");
     }
 }

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -7,7 +7,6 @@ use std::sync::Arc;
 
 use megatokyo_core::image_cache::ImageCache;
 use megatokyo_core::store::Store;
-use megatokyo_core::translate::Translator;
 
 use config::Config;
 use control::AppState;
@@ -35,17 +34,6 @@ async fn main() {
     };
 
     let image_cache = ImageCache::new(ImageCache::default_cache_dir());
-    let translator =
-        (!config.deepl_api_key.is_empty()).then(|| Translator::new(config.deepl_api_key.clone()));
-
-    let state = Arc::new(AppState {
-        store,
-        image_cache,
-        translator,
-        token: config.api_token.clone(),
-        backfilling: AtomicBool::new(false),
-        check_requested: tokio::sync::Notify::new(),
-    });
 
     let bind: std::net::SocketAddr = match config.bind.parse() {
         Ok(addr) => addr,
@@ -55,12 +43,21 @@ async fn main() {
         }
     };
 
+    let state = Arc::new(AppState {
+        store,
+        image_cache,
+        token: config.api_token.clone(),
+        config: tokio::sync::RwLock::new(config),
+        config_path,
+        backfilling: AtomicBool::new(false),
+        check_requested: tokio::sync::Notify::new(),
+    });
+
     let client = reqwest::Client::new();
     let poll_state = state.clone();
     let poll_client = client.clone();
-    let poll_interval = std::time::Duration::from_secs(config.poll_interval_minutes * 60);
     tokio::spawn(async move {
-        poll::run_loop(poll_client, poll_state, poll_interval).await;
+        poll::run_loop(poll_client, poll_state).await;
     });
 
     if let Err(err) = control::serve(bind, state).await {

--- a/daemon/src/poll.rs
+++ b/daemon/src/poll.rs
@@ -34,17 +34,16 @@ pub async fn run_once(client: &reqwest::Client, state: &AppState) {
     }
 }
 
-/// Runs [`run_once`] immediately, then again every `interval`, and
-/// immediately whenever `state.check_requested` is notified (`POST
-/// /check`) — whichever comes first. A `poll_in_progress` guard (mirroring
-/// the original's `_workInProgress` flag) means an in-flight cycle just
-/// keeps running rather than being interrupted or double-started by an
-/// overlapping trigger.
-pub async fn run_loop(
-    client: reqwest::Client,
-    state: Arc<AppState>,
-    interval: std::time::Duration,
-) {
+/// Runs [`run_once`] immediately, then again every
+/// `state.config`'s `poll_interval_minutes` (re-read fresh each time round
+/// the loop, so a change made via `POST /config` takes effect on the very
+/// next sleep rather than needing a restart), and immediately whenever
+/// `state.check_requested` is notified (`POST /check`) — whichever comes
+/// first. A `poll_in_progress` guard (mirroring the original's
+/// `_workInProgress` flag) means an in-flight cycle just keeps running
+/// rather than being interrupted or double-started by an overlapping
+/// trigger.
+pub async fn run_loop(client: reqwest::Client, state: Arc<AppState>) {
     let poll_in_progress = AtomicBool::new(false);
     loop {
         if poll_in_progress
@@ -54,6 +53,8 @@ pub async fn run_loop(
             run_once(&client, &state).await;
             poll_in_progress.store(false, Ordering::SeqCst);
         }
+        let interval =
+            std::time::Duration::from_secs(state.config.read().await.poll_interval_minutes * 60);
         tokio::select! {
             _ = tokio::time::sleep(interval) => {}
             _ = state.check_requested.notified() => {}

--- a/gui/src/background.rs
+++ b/gui/src/background.rs
@@ -13,6 +13,7 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
+use crate::config::{gui_config_path, GuiConfig};
 use crate::daemon_link::{self, DaemonLink};
 use crate::notification::Notifier;
 
@@ -96,16 +97,17 @@ fn fetch_status(
     })
 }
 
-/// Takes the already-resolved [`DaemonLink`] as a parameter rather than
-/// calling [`daemon_link::resolve`] itself, so tests can point this at a
-/// mock server directly instead of going through `$XDG_CONFIG_HOME` (a
-/// process-global that parallel `cargo test` runs can't safely mutate per
-/// test).
+/// Takes the already-resolved [`DaemonLink`] and `notifications_enabled` as
+/// parameters rather than resolving them itself, so tests can supply both
+/// directly instead of going through `$XDG_CONFIG_HOME` (a process-global
+/// that parallel `cargo test` runs can't safely mutate per test) — see
+/// [`run`] for where each is actually read, fresh, every tick.
 fn tick(
     client: &reqwest::blocking::Client,
     link: &DaemonLink,
     notifier: &dyn Notifier,
     state_path: &std::path::Path,
+    notifications_enabled: bool,
 ) {
     let status = match fetch_status(client, link) {
         Ok(status) => status,
@@ -116,10 +118,13 @@ fn tick(
     };
 
     let previous = LastSeen::load(state_path);
-    if is_new(previous.last_strip_number, status.last_strip_number) {
+    // State is still tracked either way, notifications_enabled or not —
+    // flipping the toggle back on shouldn't cause a backlog of "new"
+    // numbers that actually arrived while it was off.
+    if notifications_enabled && is_new(previous.last_strip_number, status.last_strip_number) {
         notifier.new_strip(status.last_strip_number);
     }
-    if is_new(previous.last_rant_number, status.last_rant_number) {
+    if notifications_enabled && is_new(previous.last_rant_number, status.last_rant_number) {
         notifier.new_rant(status.last_rant_number);
     }
 
@@ -137,8 +142,13 @@ pub fn run(notifier: &dyn Notifier, interval: Duration) {
         .expect("building the HTTP client should never fail with no custom TLS config");
     let path = state_path();
     loop {
+        // Read fresh every tick (a plain file read, cheap compared to the
+        // /status request in tick()) so toggling the Settings screen's
+        // notifications switch takes effect on the very next tick, not
+        // just after a restart.
+        let notifications_enabled = GuiConfig::load(&gui_config_path()).notifications_enabled;
         match daemon_link::resolve() {
-            Some(link) => tick(&client, &link, notifier, &path),
+            Some(link) => tick(&client, &link, notifier, &path, notifications_enabled),
             None => log::warn!("no daemon available to poll"),
         }
         std::thread::sleep(interval);
@@ -226,10 +236,57 @@ mod tests {
 
         let notifier = RecordingNotifier::default();
         let client = reqwest::blocking::Client::new();
-        tick(&client, &link, &notifier, &state_path);
+        tick(&client, &link, &notifier, &state_path, true);
 
         assert_eq!(*notifier.strips.borrow(), vec![1619]);
         assert_eq!(*notifier.rants.borrow(), Vec::<i32>::new());
+        assert_eq!(
+            LastSeen::load(&state_path),
+            LastSeen {
+                last_strip_number: Some(1619),
+                last_rant_number: Some(1107),
+            }
+        );
+    }
+
+    #[test]
+    fn tick_tracks_state_but_stays_silent_when_notifications_are_disabled() {
+        use wiremock::matchers::{method, path as path_matcher};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let server = rt.block_on(async {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path_matcher("/status"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "last_check": null, "last_strip_number": 1619, "last_rant_number": 1107, "backfilling": false
+                })))
+                .mount(&server)
+                .await;
+            server
+        });
+        let link = DaemonLink {
+            base_url: server.uri(),
+            token: "test-token".to_string(),
+        };
+
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("last_seen.toml");
+        LastSeen {
+            last_strip_number: Some(1618),
+            last_rant_number: Some(1106),
+        }
+        .save(&state_path);
+
+        let notifier = RecordingNotifier::default();
+        let client = reqwest::blocking::Client::new();
+        tick(&client, &link, &notifier, &state_path, false);
+
+        assert_eq!(*notifier.strips.borrow(), Vec::<i32>::new());
+        assert_eq!(*notifier.rants.borrow(), Vec::<i32>::new());
+        // State still advances even while silenced, so re-enabling later
+        // doesn't dump a backlog of now-stale "new" numbers.
         assert_eq!(
             LastSeen::load(&state_path),
             LastSeen {

--- a/gui/src/config.rs
+++ b/gui/src/config.rs
@@ -1,0 +1,166 @@
+//! This GUI's own config: `$XDG_CONFIG_HOME/megatokyo-gui/config.toml`.
+//!
+//! Hand-rolled flat-TOML read/write, not the `toml` crate — see
+//! `daemon_link`'s own doc comment: four scalar fields don't justify the one
+//! external dependency this otherwise dependency-light binary would gain.
+//! `daemon_link::configured_remote`/`poll_interval_minutes` keep their own
+//! read-only parsing (unchanged, already tested); this module is the
+//! write-back half the Settings screen needs — see the control server in
+//! `control.rs` that calls [`GuiConfig::save`].
+
+use std::path::PathBuf;
+
+pub fn gui_config_path() -> PathBuf {
+    let config_home = std::env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            PathBuf::from(std::env::var_os("HOME").unwrap_or_default()).join(".config")
+        });
+    config_home.join("megatokyo-gui").join("config.toml")
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct GuiConfig {
+    pub remote_base_url: String,
+    pub remote_api_token: String,
+    pub poll_interval_minutes: u64,
+    pub notifications_enabled: bool,
+}
+
+impl Default for GuiConfig {
+    fn default() -> Self {
+        Self {
+            remote_base_url: String::new(),
+            remote_api_token: String::new(),
+            // Matches megatokyo-daemon's own default poll interval — see
+            // daemon_link::poll_interval_minutes's doc comment.
+            poll_interval_minutes: 15,
+            notifications_enabled: true,
+        }
+    }
+}
+
+impl GuiConfig {
+    pub fn load(path: &std::path::Path) -> Self {
+        let Ok(contents) = std::fs::read_to_string(path) else {
+            return Self::default();
+        };
+        let defaults = Self::default();
+        Self {
+            remote_base_url: read_string(&contents, "remote_base_url")
+                .unwrap_or(defaults.remote_base_url),
+            remote_api_token: read_string(&contents, "remote_api_token")
+                .unwrap_or(defaults.remote_api_token),
+            poll_interval_minutes: read_string(&contents, "poll_interval_minutes")
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(defaults.poll_interval_minutes),
+            notifications_enabled: read_string(&contents, "notifications_enabled")
+                .map(|v| v == "true")
+                .unwrap_or(defaults.notifications_enabled),
+        }
+    }
+
+    pub fn save(&self, path: &std::path::Path) -> std::io::Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let contents = format!(
+            "remote_base_url = \"{}\"\nremote_api_token = \"{}\"\npoll_interval_minutes = {}\nnotifications_enabled = {}\n",
+            escape(&self.remote_base_url),
+            escape(&self.remote_api_token),
+            self.poll_interval_minutes,
+            self.notifications_enabled,
+        );
+        std::fs::write(path, contents)
+    }
+}
+
+/// Same restricted, hand-rolled scalar parsing as `daemon_link`'s
+/// `read_toml_string_field` (no nesting, no multi-line values) — reads
+/// either a quoted string or a bare token (covers this module's own
+/// non-string fields too: `15`, `true`), whichever the line actually has.
+fn read_string(contents: &str, key: &str) -> Option<String> {
+    contents.lines().find_map(|line| {
+        let rest = line.trim().strip_prefix(key)?.trim_start();
+        let rest = rest.strip_prefix('=')?.trim();
+        Some(match rest.strip_prefix('"') {
+            Some(quoted) => unescape(quoted.strip_suffix('"')?),
+            None => rest.to_string(),
+        })
+    })
+}
+
+fn escape(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+/// Inverse of [`escape`] — a char-by-char scan (not sequential `.replace()`
+/// calls, which would misinterpret a `\\` that escape produced as a literal
+/// backslash into a second escape pass over its own output).
+fn unescape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars();
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            match chars.next() {
+                Some(next) => out.push(next),
+                None => out.push('\\'),
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn load_returns_defaults_when_the_file_is_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = GuiConfig::load(&dir.path().join("does-not-exist.toml"));
+        assert_eq!(config, GuiConfig::default());
+    }
+
+    #[test]
+    fn a_saved_config_round_trips_through_load() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let config = GuiConfig {
+            remote_base_url: "https://megatokyo.example.com".to_string(),
+            remote_api_token: "abc123".to_string(),
+            poll_interval_minutes: 30,
+            notifications_enabled: false,
+        };
+        config.save(&path).unwrap();
+        assert_eq!(GuiConfig::load(&path), config);
+    }
+
+    #[test]
+    fn save_escapes_quotes_and_backslashes_in_string_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let config = GuiConfig {
+            remote_api_token: "has \"quotes\" and \\backslash".to_string(),
+            ..GuiConfig::default()
+        };
+        config.save(&path).unwrap();
+        assert_eq!(
+            GuiConfig::load(&path).remote_api_token,
+            config.remote_api_token
+        );
+    }
+
+    #[test]
+    fn load_fills_in_defaults_for_fields_missing_from_an_older_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, "remote_base_url = \"https://x\"\n").unwrap();
+        let config = GuiConfig::load(&path);
+        assert_eq!(config.remote_base_url, "https://x");
+        assert_eq!(config.poll_interval_minutes, 15);
+        assert!(config.notifications_enabled);
+    }
+}

--- a/gui/src/control.rs
+++ b/gui/src/control.rs
@@ -1,0 +1,219 @@
+//! Local control server for the windowed GUI's own Settings screen —
+//! same pattern as `kio-protondrive`'s `wizard::main` and
+//! `linux_hello_config`'s own control server, just hosted by this launcher
+//! instead of a setup wizard: a plain `TcpListener` on `127.0.0.1:0`
+//! (OS-assigned port), started unconditionally alongside the windowed QML
+//! view, one thread per connection, manual HTTP request-line/header
+//! parsing. Loopback-only, single-user, trusted-local-process threat model
+//! throughout (see `megatokyo_core::local_ctrl`'s own doc comment) — the
+//! token defends against another local user guessing the port, not a
+//! network attacker.
+//!
+//! `--background` mode never starts this: nothing but the windowed QML view
+//! ever needs to write this GUI's own config.
+
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::thread;
+
+use megatokyo_core::local_ctrl::{
+    constant_time_eq, extract_header, extract_query_param, json_escape, request_method,
+    request_path,
+};
+
+use crate::config::{gui_config_path, GuiConfig};
+
+const TOKEN_HEADER: &str = "x-megatokyo-gui-ctrl-token";
+
+/// Binds the control server and returns its assigned port. Panics if the
+/// bind itself fails (loopback on port 0 essentially never does) — mirrors
+/// `kio-protondrive-wizard`'s own `start_control_server`, which treats this
+/// the same way: there is no reasonable fallback for "the Settings screen's
+/// backend couldn't start at all".
+pub fn start(token: String) -> u16 {
+    let listener =
+        TcpListener::bind("127.0.0.1:0").expect("unable to start the local control server");
+    let port = listener.local_addr().unwrap().port();
+    thread::spawn(move || {
+        for stream in listener.incoming().flatten() {
+            let token = token.clone();
+            thread::spawn(move || handle_connection(stream, &token));
+        }
+    });
+    port
+}
+
+fn handle_connection(mut stream: TcpStream, expected_token: &str) {
+    let mut buf = [0u8; 4096];
+    let Ok(n) = stream.read(&mut buf) else {
+        return;
+    };
+    let req = String::from_utf8_lossy(&buf[..n]).into_owned();
+    let path = request_path(&req).to_string();
+
+    let authorized = extract_header(&req, TOKEN_HEADER)
+        .map(|t| constant_time_eq(t, expected_token))
+        .unwrap_or(false);
+
+    let (status, body) = if !authorized {
+        (
+            "403 Forbidden",
+            "{\"ok\":false,\"error\":\"forbidden\"}".to_string(),
+        )
+    } else {
+        match path.as_str() {
+            "/gui-config" => route_gui_config(&req, &gui_config_path()),
+            _ => (
+                "404 Not Found",
+                "{\"ok\":false,\"error\":\"not found\"}".to_string(),
+            ),
+        }
+    };
+
+    let response = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    let _ = stream.write_all(response.as_bytes());
+}
+
+fn config_json(config: &GuiConfig) -> String {
+    format!(
+        "{{\"remote_base_url\":\"{}\",\"remote_api_token\":\"{}\",\"poll_interval_minutes\":{},\"notifications_enabled\":{}}}",
+        json_escape(&config.remote_base_url),
+        json_escape(&config.remote_api_token),
+        config.poll_interval_minutes,
+        config.notifications_enabled,
+    )
+}
+
+/// `GET` reports the current config, `POST` applies whichever query params
+/// are present (each field independently updatable, like the daemon's own
+/// `/config`) and persists the result. Takes `path` as a parameter (rather
+/// than resolving `gui_config_path()` itself) so tests can point it at a
+/// tempdir instead of the real user config.
+fn route_gui_config(req: &str, path: &std::path::Path) -> (&'static str, String) {
+    match request_method(req) {
+        "GET" => ("200 OK", config_json(&GuiConfig::load(path))),
+        "POST" => {
+            let mut config = GuiConfig::load(path);
+            if let Some(v) = extract_query_param(req, "remote_base_url") {
+                config.remote_base_url = v;
+            }
+            if let Some(v) = extract_query_param(req, "remote_api_token") {
+                config.remote_api_token = v;
+            }
+            if let Some(v) = extract_query_param(req, "poll_interval_minutes") {
+                match v.parse::<u64>() {
+                    Ok(m) if m > 0 => config.poll_interval_minutes = m,
+                    _ => {
+                        return (
+                            "400 Bad Request",
+                            "{\"ok\":false,\"error\":\"poll_interval_minutes must be a positive integer\"}"
+                                .to_string(),
+                        )
+                    }
+                }
+            }
+            if let Some(v) = extract_query_param(req, "notifications_enabled") {
+                config.notifications_enabled = v == "true";
+            }
+            match config.save(path) {
+                Ok(()) => ("200 OK", config_json(&config)),
+                Err(err) => (
+                    "500 Internal Server Error",
+                    format!(
+                        "{{\"ok\":false,\"error\":\"{}\"}}",
+                        json_escape(&err.to_string())
+                    ),
+                ),
+            }
+        }
+        _ => (
+            "404 Not Found",
+            "{\"ok\":false,\"error\":\"not found\"}".to_string(),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn route_gui_config_get_reports_defaults_when_unconfigured() {
+        let dir = tempfile::tempdir().unwrap();
+        let (status, body) = route_gui_config(
+            "GET /gui-config HTTP/1.1\r\n",
+            &dir.path().join("config.toml"),
+        );
+        assert_eq!(status, "200 OK");
+        assert!(body.contains("\"poll_interval_minutes\":15"));
+        assert!(body.contains("\"notifications_enabled\":true"));
+    }
+
+    #[test]
+    fn route_gui_config_post_updates_only_the_given_fields_and_persists_them() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+
+        let (status, body) = route_gui_config(
+            "POST /gui-config?remote_base_url=https%3A%2F%2Fexample.com HTTP/1.1\r\n",
+            &path,
+        );
+        assert_eq!(status, "200 OK");
+        assert!(body.contains("\"remote_base_url\":\"https://example.com\""));
+
+        let (_, body) = route_gui_config(
+            "POST /gui-config?notifications_enabled=false HTTP/1.1\r\n",
+            &path,
+        );
+        // The URL set by the previous call is still there — a partial
+        // update never clobbers fields it wasn't given.
+        assert!(body.contains("\"remote_base_url\":\"https://example.com\""));
+        assert!(body.contains("\"notifications_enabled\":false"));
+
+        assert_eq!(
+            GuiConfig::load(&path).remote_base_url,
+            "https://example.com"
+        );
+    }
+
+    #[test]
+    fn route_gui_config_post_rejects_a_non_positive_poll_interval() {
+        let dir = tempfile::tempdir().unwrap();
+        let (status, _) = route_gui_config(
+            "POST /gui-config?poll_interval_minutes=0 HTTP/1.1\r\n",
+            &dir.path().join("config.toml"),
+        );
+        assert_eq!(status, "400 Bad Request");
+    }
+
+    #[test]
+    fn a_request_without_the_token_header_is_forbidden_end_to_end() {
+        let port = start("secret".to_string());
+        let mut stream =
+            TcpStream::connect(("127.0.0.1", port)).expect("control server should be listening");
+        stream
+            .write_all(b"GET /gui-config HTTP/1.1\r\n\r\n")
+            .unwrap();
+        let mut response = String::new();
+        stream.read_to_string(&mut response).unwrap();
+        assert!(response.starts_with("HTTP/1.1 403 Forbidden"));
+    }
+
+    #[test]
+    fn a_request_with_the_right_token_reaches_the_route_end_to_end() {
+        let port = start("secret".to_string());
+        let mut stream =
+            TcpStream::connect(("127.0.0.1", port)).expect("control server should be listening");
+        stream
+            .write_all(
+                format!("GET /gui-config HTTP/1.1\r\n{TOKEN_HEADER}: secret\r\n\r\n").as_bytes(),
+            )
+            .unwrap();
+        let mut response = String::new();
+        stream.read_to_string(&mut response).unwrap();
+        assert!(response.starts_with("HTTP/1.1 200 OK"));
+    }
+}

--- a/gui/src/daemon_link.rs
+++ b/gui/src/daemon_link.rs
@@ -19,19 +19,6 @@ pub struct DaemonLink {
     pub token: String,
 }
 
-/// This binary's own config: `$XDG_CONFIG_HOME/megatokyo-gui/config.toml`.
-/// Only meaningful field right now is an optional remote daemon override —
-/// `remote_base_url`/`remote_api_token` both non-empty means "don't manage
-/// a local daemon at all, just use this one".
-fn gui_config_path() -> PathBuf {
-    let config_home = std::env::var_os("XDG_CONFIG_HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| {
-            PathBuf::from(std::env::var_os("HOME").unwrap_or_default()).join(".config")
-        });
-    config_home.join("megatokyo-gui").join("config.toml")
-}
-
 /// Same path `megatokyo-daemon`'s own `config::Config::default_path()`
 /// resolves to — duplicated rather than shared via a dependency, since
 /// pulling in the daemon crate (or a config-parsing dependency) just for
@@ -67,7 +54,7 @@ fn read_toml_string_field(contents: &str, key: &str) -> Option<String> {
 /// `megatokyo-daemon`'s `config::default_poll_interval_minutes`) since
 /// there's rarely a reason for the two to disagree.
 pub fn poll_interval_minutes() -> u64 {
-    std::fs::read_to_string(gui_config_path())
+    std::fs::read_to_string(crate::config::gui_config_path())
         .ok()
         .and_then(|contents| {
             contents.lines().find_map(|line| {
@@ -83,7 +70,7 @@ pub fn poll_interval_minutes() -> u64 {
 
 /// Reads this GUI's own config, if a remote daemon override is set there.
 fn configured_remote() -> Option<DaemonLink> {
-    let contents = std::fs::read_to_string(gui_config_path()).ok()?;
+    let contents = std::fs::read_to_string(crate::config::gui_config_path()).ok()?;
     let base_url = read_toml_string_field(&contents, "remote_base_url")?;
     let token = read_toml_string_field(&contents, "remote_api_token")?;
     (!base_url.is_empty() && !token.is_empty()).then_some(DaemonLink { base_url, token })

--- a/gui/src/launcher.rs
+++ b/gui/src/launcher.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::thread;
 
-use megatokyo_core::local_ctrl::{runtime_dir, write_owner_only_file};
+use megatokyo_core::local_ctrl::{generate_ctrl_token, runtime_dir, write_owner_only_file};
 
 use crate::daemon_link::DaemonLink;
 
@@ -53,7 +53,8 @@ fn find_qml_path() -> PathBuf {
 
 pub fn run(link: &DaemonLink) -> std::process::ExitCode {
     let uid = crate::daemon_link::current_uid();
-    let lock_path = runtime_dir(uid).join("megatokyo-gui.lock");
+    let runtime_dir_path = runtime_dir(uid);
+    let lock_path = runtime_dir_path.join("megatokyo-gui.lock");
     if !acquire_single_instance_lock(&lock_path) {
         eprintln!("Megatokyo is already open.");
         return std::process::ExitCode::SUCCESS;
@@ -68,6 +69,21 @@ pub fn run(link: &DaemonLink) -> std::process::ExitCode {
         return std::process::ExitCode::FAILURE;
     }
 
+    // Local control server for the Settings screen's write-back — see
+    // control.rs's own doc comment. Port/token written to two discovery
+    // files QML reads once, synchronously, at startup (same pattern as
+    // linux_hello_config's/kio-protondrive-wizard's own control server).
+    let ctrl_token = generate_ctrl_token();
+    let ctrl_port = crate::control::start(ctrl_token.clone());
+    let _ = write_owner_only_file(
+        &runtime_dir_path.join("megatokyo-gui-ctrl.port"),
+        &ctrl_port.to_string(),
+    );
+    let _ = write_owner_only_file(
+        &runtime_dir_path.join("megatokyo-gui-ctrl.token"),
+        &ctrl_token,
+    );
+
     let qml_import_paths = ["/usr/lib/x86_64-linux-gnu/qt6/qml", "/usr/share/qt6/qml"].join(":");
     let qt_plugin_paths = [
         "/usr/lib/x86_64-linux-gnu/qt6/plugins",
@@ -75,9 +91,11 @@ pub fn run(link: &DaemonLink) -> std::process::ExitCode {
     ]
     .join(":");
 
-    // base_url/token passed positionally after `--`, not as env vars: QML
-    // reads `Qt.application.arguments`, but not always the process
-    // environment (see linux_hello_config's own note on this).
+    // base_url/token/runtime_dir passed positionally after `--`, not as env
+    // vars: QML reads `Qt.application.arguments`, but not always the
+    // process environment (see linux_hello_config's own note on this).
+    // runtime_dir is what QML needs to find the ctrl port/token files
+    // written above.
     let mut cmd = Command::new("qml6");
     cmd.arg("-name")
         .arg("megatokyo")
@@ -85,6 +103,7 @@ pub fn run(link: &DaemonLink) -> std::process::ExitCode {
         .arg("--")
         .arg(&link.base_url)
         .arg(&link.token)
+        .arg(&runtime_dir_path)
         .env("QML_IMPORT_PATH", &qml_import_paths)
         .env("QML2_IMPORT_PATH", &qml_import_paths)
         .env("QT_PLUGIN_PATH", &qt_plugin_paths)

--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -1,4 +1,6 @@
 mod background;
+mod config;
+mod control;
 mod daemon_link;
 mod launcher;
 mod notification;

--- a/qml/GuiCtrlApi.qml
+++ b/qml/GuiCtrlApi.qml
@@ -1,0 +1,45 @@
+import QtQuick
+
+// Thin wrapper around XMLHttpRequest for this GUI's own local control
+// server (see gui::control) — same shape as Api.qml, but for the
+// gui-ctrl-token header the launcher generates fresh each run, not the
+// daemon's own token.
+QtObject {
+    id: root
+
+    property string baseUrl: ""
+    property string token: ""
+
+    function request(method, path, onSuccess, onError) {
+        var xhr = new XMLHttpRequest()
+        xhr.open(method, baseUrl + path)
+        xhr.setRequestHeader("x-megatokyo-gui-ctrl-token", token)
+        xhr.onreadystatechange = function () {
+            if (xhr.readyState !== XMLHttpRequest.DONE)
+                return
+            if (xhr.status >= 200 && xhr.status < 300) {
+                var body = null
+                if (xhr.responseText.length > 0) {
+                    try {
+                        body = JSON.parse(xhr.responseText)
+                    } catch (e) {
+                        body = null
+                    }
+                }
+                if (onSuccess)
+                    onSuccess(body)
+            } else if (onError) {
+                onError(xhr.status, xhr.responseText)
+            }
+        }
+        xhr.send()
+    }
+
+    function get(path, onSuccess, onError) {
+        request("GET", path, onSuccess, onError)
+    }
+
+    function post(path, onSuccess, onError) {
+        request("POST", path, onSuccess, onError)
+    }
+}

--- a/qml/SettingsScreen.qml
+++ b/qml/SettingsScreen.qml
@@ -1,0 +1,468 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+// Settings screen: this daemon's own connection details (read-only,
+// copyable — for pasting into another device's "remote daemon" section
+// below), a remote-daemon override, DeepL translation + this daemon's poll
+// interval (daemon-side, GET/POST /config — see daemon::control), and this
+// GUI's own notifications toggle + background poll interval (gui-side,
+// GET/POST /gui-config via guiCtrlApi — see gui::control).
+Item {
+    id: root
+
+    property var api: null
+    property var guiCtrlApi: null
+    property string localBaseUrl: ""
+    property string localToken: ""
+
+    readonly property var theme: Theme {}
+
+    property string remoteBaseUrl: ""
+    property string remoteApiToken: ""
+    property bool notificationsEnabled: true
+    property int guiPollIntervalMinutes: 15
+
+    property string deeplApiKey: ""
+    property int daemonPollIntervalMinutes: 15
+
+    property string remoteStatus: ""
+    property string notificationsStatus: ""
+    property string daemonStatus: ""
+
+    function loadRemoteSettings() {
+        if (!guiCtrlApi)
+            return
+        guiCtrlApi.get("/gui-config", function (body) {
+            if (!body)
+                return
+            root.remoteBaseUrl = body.remote_base_url || ""
+            root.remoteApiToken = body.remote_api_token || ""
+            root.notificationsEnabled = body.notifications_enabled !== false
+            root.guiPollIntervalMinutes = body.poll_interval_minutes || 15
+        })
+    }
+
+    function loadDaemonSettings() {
+        if (!api)
+            return
+        api.get("/config", function (body) {
+            if (!body)
+                return
+            root.deeplApiKey = body.deepl_api_key || ""
+            root.daemonPollIntervalMinutes = body.poll_interval_minutes || 15
+        })
+    }
+
+    onGuiCtrlApiChanged: loadRemoteSettings()
+    onApiChanged: loadDaemonSettings()
+    Component.onCompleted: {
+        loadRemoteSettings()
+        loadDaemonSettings()
+    }
+
+    function saveRemote() {
+        root.remoteStatus = ""
+        guiCtrlApi.post(
+            "/gui-config?remote_base_url=" + encodeURIComponent(remoteUrlField.text)
+            + "&remote_api_token=" + encodeURIComponent(remoteTokenField.text),
+            function () { root.remoteStatus = I18n.tr("settings.saved") },
+            function () { root.remoteStatus = I18n.tr("settings.saveFailed") }
+        )
+    }
+
+    function saveNotifications() {
+        root.notificationsStatus = ""
+        guiCtrlApi.post(
+            "/gui-config?notifications_enabled=" + (notificationsCheck.checked ? "true" : "false")
+            + "&poll_interval_minutes=" + guiPollField.text,
+            function () { root.notificationsStatus = I18n.tr("settings.saved") },
+            function () { root.notificationsStatus = I18n.tr("settings.saveFailed") }
+        )
+    }
+
+    function saveDaemon() {
+        root.daemonStatus = ""
+        api.post(
+            "/config?deepl_api_key=" + encodeURIComponent(deeplField.text)
+            + "&poll_interval_minutes=" + daemonPollField.text,
+            function () { root.daemonStatus = I18n.tr("settings.saved") },
+            function () { root.daemonStatus = I18n.tr("settings.saveFailed") }
+        )
+    }
+
+    function copyField(field) {
+        field.selectAll()
+        field.copy()
+        field.deselect()
+    }
+
+    ScrollView {
+        anchors.fill: parent
+        contentWidth: availableWidth
+
+        ColumnLayout {
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.top: parent.top
+            anchors.margins: 28
+            spacing: 20
+
+            Label {
+                text: I18n.tr("settings.title")
+                font.family: theme.fontDisplay
+                font.pixelSize: 20
+                font.bold: true
+                color: theme.text
+            }
+
+            // -- this daemon ------------------------------------------------
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.preferredHeight: thisDaemonColumn.implicitHeight + 32
+                radius: 12
+                color: theme.panelRaised
+                border.color: theme.lineSoft
+                border.width: 1
+
+                ColumnLayout {
+                    id: thisDaemonColumn
+                    anchors.fill: parent
+                    anchors.margins: 16
+                    spacing: 10
+
+                    Label {
+                        text: I18n.tr("settings.thisDaemonTitle")
+                        color: theme.teal
+                        font.family: theme.fontMono
+                        font.pixelSize: 10
+                    }
+                    Label {
+                        text: I18n.tr("settings.thisDaemonHint")
+                        color: theme.textDim
+                        font.pixelSize: 12
+                        wrapMode: Text.WordWrap
+                        Layout.fillWidth: true
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 8
+                        Rectangle {
+                            Layout.fillWidth: true
+                            Layout.preferredHeight: 36
+                            radius: 8
+                            color: theme.panelSunken
+                            border.color: theme.line
+                            border.width: 1
+                            TextField {
+                                id: localUrlField
+                                anchors.fill: parent
+                                anchors.margins: 6
+                                background: null
+                                color: theme.textDim
+                                font.family: theme.fontMono
+                                font.pixelSize: 12
+                                readOnly: true
+                                selectByMouse: true
+                                text: root.localBaseUrl
+                            }
+                        }
+                        Button {
+                            text: I18n.tr("settings.copy")
+                            onClicked: root.copyField(localUrlField)
+                        }
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 8
+                        Rectangle {
+                            Layout.fillWidth: true
+                            Layout.preferredHeight: 36
+                            radius: 8
+                            color: theme.panelSunken
+                            border.color: theme.line
+                            border.width: 1
+                            TextField {
+                                id: localTokenField
+                                anchors.fill: parent
+                                anchors.margins: 6
+                                background: null
+                                color: theme.textDim
+                                font.family: theme.fontMono
+                                font.pixelSize: 12
+                                readOnly: true
+                                selectByMouse: true
+                                echoMode: TextInput.Password
+                                text: root.localToken
+                            }
+                        }
+                        Button {
+                            text: I18n.tr("settings.copy")
+                            onClicked: root.copyField(localTokenField)
+                        }
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 8
+
+                        Label {
+                            text: I18n.tr("settings.daemonPollIntervalLabel")
+                            color: theme.textDim
+                            font.pixelSize: 12
+                        }
+                        Rectangle {
+                            Layout.preferredWidth: 70
+                            Layout.preferredHeight: 32
+                            radius: 8
+                            color: theme.panelSunken
+                            border.color: theme.line
+                            border.width: 1
+                            TextField {
+                                id: daemonPollField
+                                anchors.fill: parent
+                                anchors.margins: 6
+                                background: null
+                                color: theme.text
+                                font.pixelSize: 12
+                                selectByMouse: true
+                                validator: IntValidator { bottom: 1 }
+                                text: root.daemonPollIntervalMinutes
+                            }
+                        }
+                        Label {
+                            text: I18n.tr("settings.deeplKeyLabel")
+                            color: theme.textDim
+                            font.pixelSize: 12
+                        }
+                        Rectangle {
+                            Layout.fillWidth: true
+                            Layout.preferredHeight: 32
+                            radius: 8
+                            color: theme.panelSunken
+                            border.color: theme.line
+                            border.width: 1
+                            TextField {
+                                id: deeplField
+                                anchors.fill: parent
+                                anchors.margins: 6
+                                background: null
+                                color: theme.text
+                                font.family: theme.fontMono
+                                font.pixelSize: 12
+                                selectByMouse: true
+                                echoMode: TextInput.Password
+                                placeholderText: I18n.tr("settings.deeplKeyPlaceholder")
+                                placeholderTextColor: theme.textFaint
+                                text: root.deeplApiKey
+                            }
+                        }
+                        Button {
+                            id: daemonSaveButton
+                            text: I18n.tr("settings.save")
+                            onClicked: root.saveDaemon()
+                            background: Rectangle { color: theme.teal; radius: 8 }
+                            contentItem: Label {
+                                text: daemonSaveButton.text
+                                color: theme.ink
+                                font.bold: true
+                                font.pixelSize: 12
+                                horizontalAlignment: Text.AlignHCenter
+                            }
+                        }
+                        Label {
+                            text: root.daemonStatus
+                            color: theme.teal
+                            font.pixelSize: 11
+                        }
+                    }
+                }
+            }
+
+            // -- remote daemon ------------------------------------------------
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.preferredHeight: remoteColumn.implicitHeight + 32
+                radius: 12
+                color: theme.panelRaised
+                border.color: theme.lineSoft
+                border.width: 1
+
+                ColumnLayout {
+                    id: remoteColumn
+                    anchors.fill: parent
+                    anchors.margins: 16
+                    spacing: 10
+
+                    Label {
+                        text: I18n.tr("settings.remoteTitle")
+                        color: theme.teal
+                        font.family: theme.fontMono
+                        font.pixelSize: 10
+                    }
+                    Label {
+                        text: I18n.tr("settings.remoteHint")
+                        color: theme.textDim
+                        font.pixelSize: 12
+                        wrapMode: Text.WordWrap
+                        Layout.fillWidth: true
+                    }
+
+                    Rectangle {
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: 36
+                        radius: 8
+                        color: theme.panelSunken
+                        border.color: theme.line
+                        border.width: 1
+                        TextField {
+                            id: remoteUrlField
+                            anchors.fill: parent
+                            anchors.margins: 6
+                            background: null
+                            color: theme.text
+                            font.family: theme.fontMono
+                            font.pixelSize: 12
+                            selectByMouse: true
+                            placeholderText: I18n.tr("settings.remoteUrlPlaceholder")
+                            placeholderTextColor: theme.textFaint
+                            text: root.remoteBaseUrl
+                        }
+                    }
+                    Rectangle {
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: 36
+                        radius: 8
+                        color: theme.panelSunken
+                        border.color: theme.line
+                        border.width: 1
+                        TextField {
+                            id: remoteTokenField
+                            anchors.fill: parent
+                            anchors.margins: 6
+                            background: null
+                            color: theme.text
+                            font.family: theme.fontMono
+                            font.pixelSize: 12
+                            selectByMouse: true
+                            echoMode: TextInput.Password
+                            placeholderText: I18n.tr("settings.remoteTokenPlaceholder")
+                            placeholderTextColor: theme.textFaint
+                            text: root.remoteApiToken
+                        }
+                    }
+                    RowLayout {
+                        spacing: 10
+                        Button {
+                            id: remoteSaveButton
+                            text: I18n.tr("settings.save")
+                            onClicked: root.saveRemote()
+                            background: Rectangle { color: theme.teal; radius: 8 }
+                            contentItem: Label {
+                                text: remoteSaveButton.text
+                                color: theme.ink
+                                font.bold: true
+                                font.pixelSize: 12
+                                horizontalAlignment: Text.AlignHCenter
+                            }
+                        }
+                        Label {
+                            text: root.remoteStatus
+                            color: theme.teal
+                            font.pixelSize: 11
+                        }
+                    }
+                }
+            }
+
+            // -- notifications ------------------------------------------------
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.preferredHeight: notifColumn.implicitHeight + 32
+                radius: 12
+                color: theme.panelRaised
+                border.color: theme.lineSoft
+                border.width: 1
+
+                ColumnLayout {
+                    id: notifColumn
+                    anchors.fill: parent
+                    anchors.margins: 16
+                    spacing: 10
+
+                    Label {
+                        text: I18n.tr("settings.notificationsTitle")
+                        color: theme.teal
+                        font.family: theme.fontMono
+                        font.pixelSize: 10
+                    }
+
+                    RowLayout {
+                        spacing: 16
+
+                        CheckBox {
+                            id: notificationsCheck
+                            text: I18n.tr("settings.notificationsToggle")
+                            checked: root.notificationsEnabled
+                            contentItem: Label {
+                                text: notificationsCheck.text
+                                color: theme.text
+                                font.pixelSize: 12
+                                leftPadding: notificationsCheck.indicator.width + 6
+                                verticalAlignment: Text.AlignVCenter
+                            }
+                        }
+
+                        Label {
+                            text: I18n.tr("settings.notificationsPollIntervalLabel")
+                            color: theme.textDim
+                            font.pixelSize: 12
+                        }
+                        Rectangle {
+                            Layout.preferredWidth: 70
+                            Layout.preferredHeight: 32
+                            radius: 8
+                            color: theme.panelSunken
+                            border.color: theme.line
+                            border.width: 1
+                            TextField {
+                                id: guiPollField
+                                anchors.fill: parent
+                                anchors.margins: 6
+                                background: null
+                                color: theme.text
+                                font.pixelSize: 12
+                                selectByMouse: true
+                                validator: IntValidator { bottom: 1 }
+                                text: root.guiPollIntervalMinutes
+                            }
+                        }
+
+                        Button {
+                            id: notifSaveButton
+                            text: I18n.tr("settings.save")
+                            onClicked: root.saveNotifications()
+                            background: Rectangle { color: theme.teal; radius: 8 }
+                            contentItem: Label {
+                                text: notifSaveButton.text
+                                color: theme.ink
+                                font.bold: true
+                                font.pixelSize: 12
+                                horizontalAlignment: Text.AlignHCenter
+                            }
+                        }
+                        Label {
+                            text: root.notificationsStatus
+                            color: theme.teal
+                            font.pixelSize: 11
+                        }
+                    }
+                }
+            }
+
+            Item { Layout.preferredHeight: 8 }
+        }
+    }
+}

--- a/qml/i18n/ar.json
+++ b/qml/i18n/ar.json
@@ -4,6 +4,7 @@
         "navReader": "القارئ",
         "navGallery": "المعرض",
         "navRants": "المقالات",
+        "navSettings": "الإعدادات",
         "statusBackfilling": "المزامنة الأولية…",
         "statusUpToDate": "محدّث"
     },
@@ -34,5 +35,24 @@
     "rants": {
         "title": "المقالات",
         "loadingTranslation": "جارٍ الترجمة…"
+    },
+    "settings": {
+        "title": "الإعدادات",
+        "thisDaemonTitle": "هذه الخدمة",
+        "thisDaemonHint": "انسخ هذا الرابط والرمز إلى قسم «خدمة بعيدة» في جهاز آخر لربطه بنفس الخدمة.",
+        "copy": "نسخ",
+        "daemonPollIntervalLabel": "فاصل التحقق (دقيقة)",
+        "deeplKeyLabel": "مفتاح API الخاص بـ DeepL",
+        "deeplKeyPlaceholder": "الصق مفتاح API الخاص بـ DeepL",
+        "save": "حفظ",
+        "saved": "تم الحفظ",
+        "saveFailed": "تعذّر الحفظ",
+        "remoteTitle": "الاتصال بخدمة بعيدة",
+        "remoteHint": "اترك كلا الحقلين فارغين لاستخدام الخدمة على هذا الجهاز.",
+        "remoteUrlPlaceholder": "https://megatokyo.example.com",
+        "remoteTokenPlaceholder": "رمز API",
+        "notificationsTitle": "الإشعارات",
+        "notificationsToggle": "إشعاري بالأشرطة والمقالات الجديدة",
+        "notificationsPollIntervalLabel": "التحقق كل (دقيقة)"
     }
 }

--- a/qml/i18n/de.json
+++ b/qml/i18n/de.json
@@ -4,6 +4,7 @@
         "navReader": "Leser",
         "navGallery": "Galerie",
         "navRants": "Rants",
+        "navSettings": "Einstellungen",
         "statusBackfilling": "Erstsynchronisierung…",
         "statusUpToDate": "Aktuell"
     },
@@ -34,5 +35,24 @@
     "rants": {
         "title": "Rants",
         "loadingTranslation": "Übersetzung läuft…"
+    },
+    "settings": {
+        "title": "Einstellungen",
+        "thisDaemonTitle": "DIESER DIENST",
+        "thisDaemonHint": "Kopiere diese URL und dieses Token in den Abschnitt „Entfernter Dienst“ eines anderen Geräts, um es mit demselben Dienst zu verbinden.",
+        "copy": "Kopieren",
+        "daemonPollIntervalLabel": "Prüfintervall (Min.)",
+        "deeplKeyLabel": "DeepL-API-Schlüssel",
+        "deeplKeyPlaceholder": "DeepL-API-Schlüssel einfügen",
+        "save": "Speichern",
+        "saved": "Gespeichert",
+        "saveFailed": "Speichern fehlgeschlagen",
+        "remoteTitle": "MIT ENTFERNTEM DIENST VERBINDEN",
+        "remoteHint": "Beide Felder leer lassen, um stattdessen den Dienst auf diesem Gerät zu verwenden.",
+        "remoteUrlPlaceholder": "https://megatokyo.beispiel.de",
+        "remoteTokenPlaceholder": "API-Token",
+        "notificationsTitle": "BENACHRICHTIGUNGEN",
+        "notificationsToggle": "Über neue Comics und Rants benachrichtigen",
+        "notificationsPollIntervalLabel": "Prüfen alle (Min.)"
     }
 }

--- a/qml/i18n/en.json
+++ b/qml/i18n/en.json
@@ -4,6 +4,7 @@
         "navReader": "Reader",
         "navGallery": "Gallery",
         "navRants": "Rants",
+        "navSettings": "Settings",
         "statusBackfilling": "Initial sync…",
         "statusUpToDate": "Up to date"
     },
@@ -34,5 +35,24 @@
     "rants": {
         "title": "Rants",
         "loadingTranslation": "Translating…"
+    },
+    "settings": {
+        "title": "Settings",
+        "thisDaemonTitle": "THIS DAEMON",
+        "thisDaemonHint": "Copy this URL and token into another device's \"Remote daemon\" section below to connect it to the same daemon.",
+        "copy": "Copy",
+        "daemonPollIntervalLabel": "Check interval (min)",
+        "deeplKeyLabel": "DeepL API key",
+        "deeplKeyPlaceholder": "Paste your DeepL API key",
+        "save": "Save",
+        "saved": "Saved",
+        "saveFailed": "Could not save",
+        "remoteTitle": "CONNECT TO A REMOTE DAEMON",
+        "remoteHint": "Leave both fields empty to use the daemon on this machine instead.",
+        "remoteUrlPlaceholder": "https://megatokyo.example.com",
+        "remoteTokenPlaceholder": "API token",
+        "notificationsTitle": "NOTIFICATIONS",
+        "notificationsToggle": "Notify me about new strips and rants",
+        "notificationsPollIntervalLabel": "Check every (min)"
     }
 }

--- a/qml/i18n/es.json
+++ b/qml/i18n/es.json
@@ -4,6 +4,7 @@
         "navReader": "Lector",
         "navGallery": "Galería",
         "navRants": "Rants",
+        "navSettings": "Ajustes",
         "statusBackfilling": "Sincronización inicial…",
         "statusUpToDate": "Actualizado"
     },
@@ -34,5 +35,24 @@
     "rants": {
         "title": "Rants",
         "loadingTranslation": "Traduciendo…"
+    },
+    "settings": {
+        "title": "Ajustes",
+        "thisDaemonTitle": "ESTE DAEMON",
+        "thisDaemonHint": "Copia esta URL y este token en la sección «Daemon remoto» de otro dispositivo para conectarlo al mismo daemon.",
+        "copy": "Copiar",
+        "daemonPollIntervalLabel": "Intervalo de comprobación (min)",
+        "deeplKeyLabel": "Clave API de DeepL",
+        "deeplKeyPlaceholder": "Pega tu clave API de DeepL",
+        "save": "Guardar",
+        "saved": "Guardado",
+        "saveFailed": "No se pudo guardar",
+        "remoteTitle": "CONECTAR A UN DAEMON REMOTO",
+        "remoteHint": "Deja ambos campos vacíos para usar el daemon de esta máquina.",
+        "remoteUrlPlaceholder": "https://megatokyo.ejemplo.com",
+        "remoteTokenPlaceholder": "Token de API",
+        "notificationsTitle": "NOTIFICACIONES",
+        "notificationsToggle": "Avisarme de nuevas tiras y rants",
+        "notificationsPollIntervalLabel": "Comprobar cada (min)"
     }
 }

--- a/qml/i18n/fr.json
+++ b/qml/i18n/fr.json
@@ -4,6 +4,7 @@
         "navReader": "Lecture",
         "navGallery": "Galerie",
         "navRants": "Rants",
+        "navSettings": "Réglages",
         "statusBackfilling": "Synchronisation initiale…",
         "statusUpToDate": "À jour"
     },
@@ -34,5 +35,24 @@
     "rants": {
         "title": "Rants",
         "loadingTranslation": "Traduction en cours…"
+    },
+    "settings": {
+        "title": "Réglages",
+        "thisDaemonTitle": "CE DÉMON",
+        "thisDaemonHint": "Copiez cette URL et ce jeton dans la section « Démon distant » d'un autre appareil pour le connecter au même démon.",
+        "copy": "Copier",
+        "daemonPollIntervalLabel": "Intervalle de vérification (min)",
+        "deeplKeyLabel": "Clé API DeepL",
+        "deeplKeyPlaceholder": "Collez votre clé API DeepL",
+        "save": "Enregistrer",
+        "saved": "Enregistré",
+        "saveFailed": "Échec de l'enregistrement",
+        "remoteTitle": "SE CONNECTER À UN DÉMON DISTANT",
+        "remoteHint": "Laissez les deux champs vides pour utiliser le démon de cette machine.",
+        "remoteUrlPlaceholder": "https://megatokyo.exemple.com",
+        "remoteTokenPlaceholder": "Jeton API",
+        "notificationsTitle": "NOTIFICATIONS",
+        "notificationsToggle": "Me notifier des nouvelles planches et rants",
+        "notificationsPollIntervalLabel": "Vérifier toutes les (min)"
     }
 }

--- a/qml/i18n/hi.json
+++ b/qml/i18n/hi.json
@@ -4,6 +4,7 @@
         "navReader": "रीडर",
         "navGallery": "गैलरी",
         "navRants": "रैंट्स",
+        "navSettings": "सेटिंग्स",
         "statusBackfilling": "प्रारंभिक सिंक हो रहा है…",
         "statusUpToDate": "अद्यतन"
     },
@@ -34,5 +35,24 @@
     "rants": {
         "title": "रैंट्स",
         "loadingTranslation": "अनुवाद हो रहा है…"
+    },
+    "settings": {
+        "title": "सेटिंग्स",
+        "thisDaemonTitle": "यह डेमन",
+        "thisDaemonHint": "इसे उसी डेमन से जोड़ने के लिए यह URL और टोकन किसी अन्य डिवाइस के \"रिमोट डेमन\" सेक्शन में कॉपी करें।",
+        "copy": "कॉपी करें",
+        "daemonPollIntervalLabel": "जांच अंतराल (मिनट)",
+        "deeplKeyLabel": "DeepL API कुंजी",
+        "deeplKeyPlaceholder": "अपनी DeepL API कुंजी पेस्ट करें",
+        "save": "सहेजें",
+        "saved": "सहेजा गया",
+        "saveFailed": "सहेजा नहीं जा सका",
+        "remoteTitle": "रिमोट डेमन से कनेक्ट करें",
+        "remoteHint": "इस मशीन के डेमन का उपयोग करने के लिए दोनों फ़ील्ड खाली छोड़ें।",
+        "remoteUrlPlaceholder": "https://megatokyo.example.com",
+        "remoteTokenPlaceholder": "API टोकन",
+        "notificationsTitle": "सूचनाएं",
+        "notificationsToggle": "नई स्ट्रिप्स और रैंट्स की सूचना दें",
+        "notificationsPollIntervalLabel": "हर (मिनट) जांचें"
     }
 }

--- a/qml/i18n/ja.json
+++ b/qml/i18n/ja.json
@@ -4,6 +4,7 @@
         "navReader": "リーダー",
         "navGallery": "ギャラリー",
         "navRants": "ラント",
+        "navSettings": "設定",
         "statusBackfilling": "初回同期中…",
         "statusUpToDate": "最新"
     },
@@ -34,5 +35,24 @@
     "rants": {
         "title": "ラント",
         "loadingTranslation": "翻訳中…"
+    },
+    "settings": {
+        "title": "設定",
+        "thisDaemonTitle": "このデーモン",
+        "thisDaemonHint": "このURLとトークンを別のデバイスの「リモートデーモン」セクションにコピーすると、同じデーモンに接続できます。",
+        "copy": "コピー",
+        "daemonPollIntervalLabel": "確認間隔(分)",
+        "deeplKeyLabel": "DeepL APIキー",
+        "deeplKeyPlaceholder": "DeepL APIキーを貼り付け",
+        "save": "保存",
+        "saved": "保存しました",
+        "saveFailed": "保存できませんでした",
+        "remoteTitle": "リモートデーモンに接続",
+        "remoteHint": "両方の項目を空にすると、このマシンのデーモンを使用します。",
+        "remoteUrlPlaceholder": "https://megatokyo.example.com",
+        "remoteTokenPlaceholder": "APIトークン",
+        "notificationsTitle": "通知",
+        "notificationsToggle": "新しいストリップとラントを通知する",
+        "notificationsPollIntervalLabel": "確認間隔(分)"
     }
 }

--- a/qml/i18n/pt.json
+++ b/qml/i18n/pt.json
@@ -4,6 +4,7 @@
         "navReader": "Leitor",
         "navGallery": "Galeria",
         "navRants": "Rants",
+        "navSettings": "Definições",
         "statusBackfilling": "Sincronização inicial…",
         "statusUpToDate": "Atualizado"
     },
@@ -34,5 +35,24 @@
     "rants": {
         "title": "Rants",
         "loadingTranslation": "Traduzindo…"
+    },
+    "settings": {
+        "title": "Definições",
+        "thisDaemonTitle": "ESTE DAEMON",
+        "thisDaemonHint": "Copie este URL e token para a secção «Daemon remoto» de outro dispositivo para ligá-lo ao mesmo daemon.",
+        "copy": "Copiar",
+        "daemonPollIntervalLabel": "Intervalo de verificação (min)",
+        "deeplKeyLabel": "Chave da API DeepL",
+        "deeplKeyPlaceholder": "Cole a sua chave da API DeepL",
+        "save": "Guardar",
+        "saved": "Guardado",
+        "saveFailed": "Não foi possível guardar",
+        "remoteTitle": "LIGAR A UM DAEMON REMOTO",
+        "remoteHint": "Deixe ambos os campos vazios para usar o daemon desta máquina.",
+        "remoteUrlPlaceholder": "https://megatokyo.exemplo.com",
+        "remoteTokenPlaceholder": "Token de API",
+        "notificationsTitle": "NOTIFICAÇÕES",
+        "notificationsToggle": "Notificar-me sobre novas tiras e rants",
+        "notificationsPollIntervalLabel": "Verificar a cada (min)"
     }
 }

--- a/qml/i18n/ru.json
+++ b/qml/i18n/ru.json
@@ -4,6 +4,7 @@
         "navReader": "Чтение",
         "navGallery": "Галерея",
         "navRants": "Рассказы",
+        "navSettings": "Настройки",
         "statusBackfilling": "Первичная синхронизация…",
         "statusUpToDate": "Актуально"
     },
@@ -34,5 +35,24 @@
     "rants": {
         "title": "Рассказы",
         "loadingTranslation": "Перевод…"
+    },
+    "settings": {
+        "title": "Настройки",
+        "thisDaemonTitle": "ЭТОТ СЕРВЕР",
+        "thisDaemonHint": "Скопируйте этот URL и токен в раздел «Удалённый сервер» на другом устройстве, чтобы подключить его к тому же серверу.",
+        "copy": "Копировать",
+        "daemonPollIntervalLabel": "Интервал проверки (мин)",
+        "deeplKeyLabel": "Ключ API DeepL",
+        "deeplKeyPlaceholder": "Вставьте ключ API DeepL",
+        "save": "Сохранить",
+        "saved": "Сохранено",
+        "saveFailed": "Не удалось сохранить",
+        "remoteTitle": "ПОДКЛЮЧИТЬСЯ К УДАЛЁННОМУ СЕРВЕРУ",
+        "remoteHint": "Оставьте оба поля пустыми, чтобы использовать сервер на этом устройстве.",
+        "remoteUrlPlaceholder": "https://megatokyo.example.com",
+        "remoteTokenPlaceholder": "Токен API",
+        "notificationsTitle": "УВЕДОМЛЕНИЯ",
+        "notificationsToggle": "Уведомлять о новых выпусках и записях",
+        "notificationsPollIntervalLabel": "Проверять каждые (мин)"
     }
 }

--- a/qml/i18n/zh.json
+++ b/qml/i18n/zh.json
@@ -4,6 +4,7 @@
         "navReader": "阅读",
         "navGallery": "画廊",
         "navRants": "闲谈",
+        "navSettings": "设置",
         "statusBackfilling": "首次同步中…",
         "statusUpToDate": "已是最新"
     },
@@ -34,5 +35,24 @@
     "rants": {
         "title": "闲谈",
         "loadingTranslation": "翻译中…"
+    },
+    "settings": {
+        "title": "设置",
+        "thisDaemonTitle": "本机守护进程",
+        "thisDaemonHint": "将此URL和令牌复制到另一台设备的“远程守护进程”部分,以连接到同一个守护进程。",
+        "copy": "复制",
+        "daemonPollIntervalLabel": "检查间隔(分钟)",
+        "deeplKeyLabel": "DeepL API 密钥",
+        "deeplKeyPlaceholder": "粘贴你的 DeepL API 密钥",
+        "save": "保存",
+        "saved": "已保存",
+        "saveFailed": "保存失败",
+        "remoteTitle": "连接到远程守护进程",
+        "remoteHint": "两个字段都留空则使用本机的守护进程。",
+        "remoteUrlPlaceholder": "https://megatokyo.example.com",
+        "remoteTokenPlaceholder": "API 令牌",
+        "notificationsTitle": "通知",
+        "notificationsToggle": "有新漫画和闲谈时通知我",
+        "notificationsPollIntervalLabel": "检查间隔(分钟)"
     }
 }

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -2,13 +2,14 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 
-// Shell: sidebar nav + the four screens reviewed with the user before this
-// was built (Home/Reader/Gallery/Rants — Settings' remote-config
-// persistence is a separate follow-up, see the project's issues). QML talks
-// to the daemon directly over its HTTP API (local or remote, see
-// gui::daemon_link), so there's nothing here for a local control server to
-// answer — base_url/token just come in as positional arguments from
-// gui::launcher.
+// Shell: sidebar nav + the five screens reviewed with the user before this
+// was built (Home/Reader/Gallery/Rants/Settings). QML talks to the daemon
+// directly over its HTTP API (local or remote, see gui::daemon_link) for
+// everything but this GUI's own config — base_url/token/guiRuntimeDir come
+// in as positional arguments from gui::launcher, the latter pointing at the
+// discovery files for gui::control's local control server (see
+// loadGuiCtrl below), which Settings uses to write this GUI's own
+// remote-daemon/notifications config back to disk.
 ApplicationWindow {
     id: window
     visible: true
@@ -18,8 +19,15 @@ ApplicationWindow {
     minimumHeight: 480
     title: "Megatokyo"
 
-    property string baseUrl: Qt.application.arguments.length > 1 ? Qt.application.arguments[Qt.application.arguments.length - 2] : ""
-    property string apiToken: Qt.application.arguments.length > 1 ? Qt.application.arguments[Qt.application.arguments.length - 1] : ""
+    // gui::launcher passes base_url/token/runtime_dir as the last three
+    // positional arguments — runtime_dir is where the local control
+    // server's port/token discovery files live (see loadGuiCtrl below and
+    // gui::control's own doc comment).
+    property string baseUrl: Qt.application.arguments.length > 2 ? Qt.application.arguments[Qt.application.arguments.length - 3] : ""
+    property string apiToken: Qt.application.arguments.length > 2 ? Qt.application.arguments[Qt.application.arguments.length - 2] : ""
+    property string guiRuntimeDir: Qt.application.arguments.length > 2 ? Qt.application.arguments[Qt.application.arguments.length - 1] : ""
+    property string guiCtrlPort: ""
+    property string guiCtrlToken: ""
 
     property var chapters: []
     property var strips: []
@@ -34,6 +42,32 @@ ApplicationWindow {
         id: api
         baseUrl: window.baseUrl
         token: window.apiToken
+    }
+
+    GuiCtrlApi {
+        id: guiCtrlApi
+        baseUrl: "http://127.0.0.1:" + window.guiCtrlPort
+        token: window.guiCtrlToken
+    }
+
+    // Synchronous, one-shot reads of the two discovery files
+    // gui::launcher::run writes before spawning qml6 — same pattern as
+    // kio-protondrive-wizard's own control-server discovery. Must happen
+    // before guiCtrlApi is used for anything.
+    function loadGuiCtrl() {
+        if (window.guiRuntimeDir === "")
+            return
+        var portXhr = new XMLHttpRequest()
+        portXhr.open("GET", "file://" + window.guiRuntimeDir + "/megatokyo-gui-ctrl.port", false)
+        portXhr.send()
+        if (portXhr.responseText !== "")
+            window.guiCtrlPort = portXhr.responseText.trim()
+
+        var tokenXhr = new XMLHttpRequest()
+        tokenXhr.open("GET", "file://" + window.guiRuntimeDir + "/megatokyo-gui-ctrl.token", false)
+        tokenXhr.send()
+        if (tokenXhr.responseText !== "")
+            window.guiCtrlToken = tokenXhr.responseText.trim()
     }
 
     function refreshChapters() {
@@ -91,7 +125,10 @@ ApplicationWindow {
         nav.currentIndex = 3
     }
 
-    Component.onCompleted: refreshAll()
+    Component.onCompleted: {
+        loadGuiCtrl()
+        refreshAll()
+    }
 
     background: Rectangle { color: theme.ink }
 
@@ -113,7 +150,7 @@ ApplicationWindow {
                 Repeater {
                     id: nav
                     property int currentIndex: 0
-                    model: [I18n.tr("app.navHome"), I18n.tr("app.navReader"), I18n.tr("app.navGallery"), I18n.tr("app.navRants")]
+                    model: [I18n.tr("app.navHome"), I18n.tr("app.navReader"), I18n.tr("app.navGallery"), I18n.tr("app.navRants"), I18n.tr("app.navSettings")]
                     delegate: Rectangle {
                         Layout.fillWidth: true
                         height: 36
@@ -186,6 +223,13 @@ ApplicationWindow {
                 id: rantsScreen
                 api: api
                 rants: window.rants
+            }
+
+            SettingsScreen {
+                api: api
+                guiCtrlApi: guiCtrlApi
+                localBaseUrl: window.baseUrl
+                localToken: window.apiToken
             }
         }
     }


### PR DESCRIPTION
Closes #11.

## Summary
- `gui::control`: a local control server for `megatokyo-gui` itself (same pattern as `linux_hello_config`/`kio-protondrive-wizard` — `TcpListener` on `127.0.0.1:0`, port/token written to `$XDG_RUNTIME_DIR` discovery files, read by QML via one synchronous XHR at startup). This is the write-back mechanism #11 was blocked on.
- `gui::config::GuiConfig`: this GUI's own config, now read *and* written (hand-rolled flat TOML, no new dependency). `daemon_link.rs` now shares its path resolution instead of duplicating it.
- `daemon::control`: new `GET`/`POST /config` for `deepl_api_key`/`poll_interval_minutes` — same authenticated HTTP API QML already talks to for everything else, local or remote. `Translator` is no longer cached on `AppState`; built fresh from the current key per request so a change applies immediately. `poll::run_loop` re-reads the interval every cycle instead of a fixed `Duration`.
- `SettingsScreen.qml`: this daemon's URL/token (read-only, copyable — for pasting into another device), remote-daemon fields, DeepL key + daemon poll interval, notifications toggle + this GUI's own background poll interval. Localized in all 10 languages.

## Test plan
- [x] `cargo build/test/clippy/fmt --workspace` — 93 tests passing
- [x] `qmllint` on the new/changed QML (only the same cosmetic `theme.*` unqualified-access warnings already present in every other screen)
- [x] Offscreen `qml6` smoke run of the whole app with a fake runtime dir — no console errors, clean exit
- [x] Real `dpkg-buildpackage` + `lintian` — new QML files land under `/usr/share/megatokyo/qml` via the existing recursive copy, no packaging changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)