### PR TITLE
fix(qml): stop clipping the tops of letters in TextField boxes

### DIFF
--- a/qml/DashboardScreen.qml
+++ b/qml/DashboardScreen.qml
@@ -63,6 +63,7 @@ Item {
                         id: searchField
                         anchors.fill: parent
                         anchors.margins: 8
+                        padding: 0
                         background: null
                         color: theme.text
                         placeholderText: I18n.tr("dashboard.searchPlaceholder")

--- a/qml/SettingsScreen.qml
+++ b/qml/SettingsScreen.qml
@@ -178,6 +178,7 @@ Item {
                                 id: localUrlField
                                 anchors.fill: parent
                                 anchors.margins: 6
+                                padding: 0
                                 background: null
                                 color: theme.textDim
                                 font.family: theme.fontMono
@@ -207,6 +208,7 @@ Item {
                                 id: localTokenField
                                 anchors.fill: parent
                                 anchors.margins: 6
+                                padding: 0
                                 background: null
                                 color: theme.textDim
                                 font.family: theme.fontMono
@@ -243,6 +245,7 @@ Item {
                                 id: daemonPollField
                                 anchors.fill: parent
                                 anchors.margins: 6
+                                padding: 0
                                 background: null
                                 color: theme.text
                                 font.pixelSize: 12
@@ -267,6 +270,7 @@ Item {
                                 id: deeplField
                                 anchors.fill: parent
                                 anchors.margins: 6
+                                padding: 0
                                 background: null
                                 color: theme.text
                                 font.family: theme.fontMono
@@ -344,6 +348,7 @@ Item {
                             id: remoteUrlField
                             anchors.fill: parent
                             anchors.margins: 6
+                            padding: 0
                             background: null
                             color: theme.text
                             font.family: theme.fontMono
@@ -365,6 +370,7 @@ Item {
                             id: remoteTokenField
                             anchors.fill: parent
                             anchors.margins: 6
+                            padding: 0
                             background: null
                             color: theme.text
                             font.family: theme.fontMono
@@ -458,6 +464,7 @@ Item {
                                 id: guiPollField
                                 anchors.fill: parent
                                 anchors.margins: 6
+                                padding: 0
                                 background: null
                                 color: theme.text
                                 font.pixelSize: 12


### PR DESCRIPTION
## Summary
- Every hand-boxed `TextField` in the app (Rectangle box + `anchors.fill`'d TextField with a few px margin, `background: null`) was stacking that margin on top of Qt Quick Controls' own default `padding: 6` — leaving too little vertical room for the glyphs, clipping ascenders (most visibly on Settings' "this daemon" URL field: "http://..." rendered as "nttp://...").
- `padding: 0` on each affected field removes the redundant inset. Fixed in `SettingsScreen.qml` (7 fields) and `DashboardScreen.qml`'s search field (same pattern, same latent bug, not yet reported but confirmed by inspection).

## Test plan
- [x] `qmllint` on both files — only the pre-existing accepted baseline warning categories
- [x] Offscreen `qml6` smoke test — clean, no stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)