### PR TITLE
fix(qml): Reader tab defaults to the last-read strip

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -220,6 +220,16 @@ ApplicationWindow {
                 favorites: window.favorites
                 toggleFavorite: window.toggleFavorite
                 saveProgress: window.saveProgress
+                // Initial default only: landing on this tab straight from
+                // the sidebar (not via Dashboard's own "resume reading",
+                // which already calls openReader explicitly) should still
+                // pick up where the user left off. Any later manual
+                // navigation (goTo, the jump dropdown, openReader) assigns
+                // currentNumber directly, which breaks this binding for
+                // the rest of the session — exactly what we want, since a
+                // stale progressStrip refresh shouldn't yank the user back
+                // to an old strip mid-navigation.
+                currentNumber: window.progressStrip
             }
 
             GalleryScreen {


### PR DESCRIPTION
## Summary
- Navigating to the Reader tab via the sidebar left it blank (ReaderScreen's `currentNumber` defaults to `-1`) unless you went through Dashboard's "resume reading" button, which already calls `openReader` explicitly.
- `readerScreen.currentNumber` now starts bound to `window.progressStrip`, so it shows the last-read strip by default as soon as `GET /progress` resolves.
- Any later manual navigation (prev/next, jump dropdown, `openReader`) assigns `currentNumber` directly, which breaks the binding for the rest of the session — a later `progressStrip` refresh won't yank the user back mid-navigation.

## Test plan
- [x] `qmllint` — only the pre-existing accepted baseline warning category
- [x] Standalone offscreen `qml6` harness verifying the binding tracks `progressStrip` until a manual assignment, then stays put through later `progressStrip` changes
- [x] Offscreen `qml6` smoke test of the full app — clean, no stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)