### PR TITLE
feat(qml): keyboard and click-to-turn-page navigation in the Reader

### DIFF
--- a/qml/ReaderScreen.qml
+++ b/qml/ReaderScreen.qml
@@ -224,6 +224,54 @@ Item {
                     asynchronous: true
                 }
 
+                // Click-to-turn-page zones — the whole left/right half of
+                // the strip, not just the small ‹/› buttons, mirroring how
+                // most comic readers let you click the page itself.
+                // Placed here (after the Image, before the favorite badge
+                // and title bar below) so those two stay on top and remain
+                // clickable in their own corners despite overlapping these
+                // zones.
+                MouseArea {
+                    anchors.left: parent.left
+                    anchors.top: parent.top
+                    anchors.bottom: parent.bottom
+                    width: parent.width / 2
+                    enabled: root.currentIndex > 0
+                    cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+                    hoverEnabled: true
+                    onClicked: root.goTo(-1)
+                    Label {
+                        anchors.left: parent.left
+                        anchors.verticalCenter: parent.verticalCenter
+                        anchors.leftMargin: 8
+                        text: "‹"
+                        font.pixelSize: 28
+                        color: theme.text
+                        opacity: parent.containsMouse ? 0.5 : 0
+                        Behavior on opacity { NumberAnimation { duration: 120 } }
+                    }
+                }
+                MouseArea {
+                    anchors.right: parent.right
+                    anchors.top: parent.top
+                    anchors.bottom: parent.bottom
+                    width: parent.width / 2
+                    enabled: root.currentIndex >= 0 && root.currentIndex < root.filteredStrips.length - 1
+                    cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+                    hoverEnabled: true
+                    onClicked: root.goTo(1)
+                    Label {
+                        anchors.right: parent.right
+                        anchors.verticalCenter: parent.verticalCenter
+                        anchors.rightMargin: 8
+                        text: "›"
+                        font.pixelSize: 28
+                        color: theme.text
+                        opacity: parent.containsMouse ? 0.5 : 0
+                        Behavior on opacity { NumberAnimation { duration: 120 } }
+                    }
+                }
+
                 Rectangle {
                     anchors.top: parent.top
                     anchors.right: parent.right

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -143,6 +143,21 @@ ApplicationWindow {
 
     background: Rectangle { color: theme.ink }
 
+    // Arrow-key paging, only while the Reader tab is actually showing —
+    // a window-wide Shortcut rather than a Keys handler on ReaderScreen
+    // itself, since StackLayout keeps every screen alive and none of them
+    // has keyboard focus by default.
+    Shortcut {
+        sequence: "Left"
+        enabled: nav.currentIndex === 1
+        onActivated: readerScreen.goTo(-1)
+    }
+    Shortcut {
+        sequence: "Right"
+        enabled: nav.currentIndex === 1
+        onActivated: readerScreen.goTo(1)
+    }
+
     RowLayout {
         anchors.fill: parent
         spacing: 0


### PR DESCRIPTION
Closes #27

## Summary
- Left/Right arrow keys page through strips (window-level `Shortcut`, active only while the Reader tab is showing).
- Clicking the left/right half of the strip image pages backward/forward too, with a faint ‹/› on hover — a much larger, more natural target than the existing small ‹/› buttons (kept as-is).

## Test plan
- [x] `qmllint` on both files — only the pre-existing accepted baseline warning categories
- [x] Offscreen `qml6` smoke test — clean, no stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)