### PR TITLE
fix(qml): pin the Rants list panel to a fixed width, keep "Rants" untranslated

### DIFF
--- a/qml/RantsScreen.qml
+++ b/qml/RantsScreen.qml
@@ -86,7 +86,14 @@ Item {
         spacing: 20
 
         ColumnLayout {
+            // minimum/maximum, not just preferred: a RowLayout is free to
+            // compress an item below its preferred width when space is
+            // tight (narrower window, a long selected title on the right)
+            // — pinning all three to 220 makes the list panel genuinely
+            // fixed-width rather than just usually-220.
             Layout.preferredWidth: 220
+            Layout.minimumWidth: 220
+            Layout.maximumWidth: 220
             Layout.fillHeight: true
             spacing: 12
 

--- a/qml/i18n/ar.json
+++ b/qml/i18n/ar.json
@@ -3,7 +3,7 @@
         "navHome": "الرئيسية",
         "navReader": "القارئ",
         "navGallery": "المعرض",
-        "navRants": "المقالات",
+        "navRants": "Rants",
         "navSettings": "الإعدادات",
         "statusBackfilling": "المزامنة الأولية…",
         "statusUpToDate": "محدّث"
@@ -34,7 +34,7 @@
         "sectionBonus": "إضافي"
     },
     "rants": {
-        "title": "المقالات",
+        "title": "Rants",
         "loadingTranslation": "جارٍ الترجمة…"
     },
     "settings": {

--- a/qml/i18n/hi.json
+++ b/qml/i18n/hi.json
@@ -3,7 +3,7 @@
         "navHome": "होम",
         "navReader": "रीडर",
         "navGallery": "गैलरी",
-        "navRants": "रैंट्स",
+        "navRants": "Rants",
         "navSettings": "सेटिंग्स",
         "statusBackfilling": "प्रारंभिक सिंक हो रहा है…",
         "statusUpToDate": "अद्यतन"
@@ -17,7 +17,7 @@
         "readPost": "पोस्ट पढ़ें",
         "statsStrips": "कैश की गई स्ट्रिप्स",
         "statsFavorites": "पसंदीदा",
-        "statsRants": "रैंट्स"
+        "statsRants": "Rants"
     },
     "reader": {
         "title": "रीडर",
@@ -34,7 +34,7 @@
         "sectionBonus": "बोनस"
     },
     "rants": {
-        "title": "रैंट्स",
+        "title": "Rants",
         "loadingTranslation": "अनुवाद हो रहा है…"
     },
     "settings": {

--- a/qml/i18n/ja.json
+++ b/qml/i18n/ja.json
@@ -3,7 +3,7 @@
         "navHome": "ホーム",
         "navReader": "リーダー",
         "navGallery": "ギャラリー",
-        "navRants": "ラント",
+        "navRants": "Rants",
         "navSettings": "設定",
         "statusBackfilling": "初回同期中…",
         "statusUpToDate": "最新"
@@ -17,7 +17,7 @@
         "readPost": "投稿を読む",
         "statsStrips": "キャッシュ済みストリップ",
         "statsFavorites": "お気に入り",
-        "statsRants": "ラント"
+        "statsRants": "Rants"
     },
     "reader": {
         "title": "リーダー",
@@ -34,7 +34,7 @@
         "sectionBonus": "ボーナス"
     },
     "rants": {
-        "title": "ラント",
+        "title": "Rants",
         "loadingTranslation": "翻訳中…"
     },
     "settings": {

--- a/qml/i18n/ru.json
+++ b/qml/i18n/ru.json
@@ -3,7 +3,7 @@
         "navHome": "Главная",
         "navReader": "Чтение",
         "navGallery": "Галерея",
-        "navRants": "Рассказы",
+        "navRants": "Rants",
         "navSettings": "Настройки",
         "statusBackfilling": "Первичная синхронизация…",
         "statusUpToDate": "Актуально"
@@ -34,7 +34,7 @@
         "sectionBonus": "Бонус"
     },
     "rants": {
-        "title": "Рассказы",
+        "title": "Rants",
         "loadingTranslation": "Перевод…"
     },
     "settings": {

--- a/qml/i18n/zh.json
+++ b/qml/i18n/zh.json
@@ -3,7 +3,7 @@
         "navHome": "主页",
         "navReader": "阅读",
         "navGallery": "画廊",
-        "navRants": "闲谈",
+        "navRants": "Rants",
         "navSettings": "设置",
         "statusBackfilling": "首次同步中…",
         "statusUpToDate": "已是最新"
@@ -17,7 +17,7 @@
         "readPost": "阅读文章",
         "statsStrips": "已缓存漫画",
         "statsFavorites": "收藏",
-        "statsRants": "闲谈"
+        "statsRants": "Rants"
     },
     "reader": {
         "title": "阅读",
@@ -34,7 +34,7 @@
         "sectionBonus": "番外"
     },
     "rants": {
-        "title": "闲谈",
+        "title": "Rants",
         "loadingTranslation": "翻译中…"
     },
     "settings": {


### PR DESCRIPTION
Closes #39

## Summary
- RantsScreen's rant-list column only set `Layout.preferredWidth: 220` — pinned `Layout.minimumWidth`/`Layout.maximumWidth` to the same value so a RowLayout can't compress it when space is tight.
- Standardized "Rants" (`app.navRants`, `rants.title`) to stay as "Rants" in every language (was inconsistent: fr/es/de/pt already kept it as-is, ru/ja/zh/ar/hi had translated it to a generic word) — confirmed with the user, it's Fred Gallagher's own name for this content on megatokyo.com, not a generic term.

## Test plan
- [x] `qmllint` — only the pre-existing accepted baseline warning category
- [x] Offscreen `qml6` smoke test — clean, no stderr
- [x] All 10 i18n files validated as parseable JSON with `app.navRants`/`rants.title` both equal to "Rants"

🤖 Generated with [Claude Code](https://claude.com/claude-code)