### PR TITLE
feat(qml): improve Rants readability — reading width, search, scrollbar

### DIFF
--- a/qml/RantsScreen.qml
+++ b/qml/RantsScreen.qml
@@ -39,6 +39,18 @@ Item {
         return r.number === selectedNumber
     })
 
+    // Filters the list only — selectedRant/onRantsChanged's "select the
+    // first one" both stay keyed off the full, unfiltered rants list, so
+    // clearing the search box never loses track of what's selected.
+    readonly property var filteredRants: {
+        var q = searchField.text.trim().toLowerCase()
+        if (q.length === 0)
+            return root.rants
+        return root.rants.filter(function (r) {
+            return r.title.toLowerCase().indexOf(q) !== -1 || String(r.number) === q
+        })
+    }
+
     readonly property string displayedContent: {
         if (!selectedRant)
             return ""
@@ -105,11 +117,40 @@ Item {
                 color: theme.text
             }
 
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.preferredHeight: 32
+                radius: 8
+                color: theme.panelSunken
+                border.color: theme.line
+                border.width: 1
+                TextField {
+                    id: searchField
+                    anchors.fill: parent
+                    anchors.margins: 6
+                    padding: 0
+                    background: null
+                    color: theme.text
+                    font.pixelSize: 12
+                    selectByMouse: true
+                    placeholderText: I18n.tr("rants.searchPlaceholder")
+                    placeholderTextColor: theme.textFaint
+                }
+            }
+
             ListView {
                 Layout.fillWidth: true
                 Layout.fillHeight: true
                 clip: true
-                model: root.rants
+                model: root.filteredRants
+                ScrollBar.vertical: ScrollBar {
+                    policy: ScrollBar.AsNeeded
+                    contentItem: Rectangle {
+                        implicitWidth: 4
+                        radius: 2
+                        color: theme.line
+                    }
+                }
                 delegate: Rectangle {
                     width: ListView.view.width
                     height: 46
@@ -196,9 +237,16 @@ Item {
             ScrollView {
                 Layout.fillWidth: true
                 Layout.fillHeight: true
+                contentWidth: availableWidth
 
+                // Capped at a comfortable reading measure and centered,
+                // rather than stretched across the full pane — full-width
+                // lines got noticeably hard to follow once the window was
+                // wide (reported by the user), same reasoning as any
+                // reading-focused app's "reader mode" column width.
                 Label {
-                    width: parent.width
+                    width: Math.min(parent.width, 720)
+                    anchors.horizontalCenter: parent.horizontalCenter
                     text: root.loadingTranslation ? I18n.tr("rants.loadingTranslation") : root.displayedContent
                     textFormat: Text.RichText
                     wrapMode: Text.WordWrap

--- a/qml/i18n/ar.json
+++ b/qml/i18n/ar.json
@@ -35,6 +35,7 @@
     },
     "rants": {
         "title": "Rants",
+        "searchPlaceholder": "ابحث عن Rant (العنوان أو الرقم)",
         "loadingTranslation": "جارٍ الترجمة…"
     },
     "settings": {

--- a/qml/i18n/de.json
+++ b/qml/i18n/de.json
@@ -35,6 +35,7 @@
     },
     "rants": {
         "title": "Rants",
+        "searchPlaceholder": "Rant suchen (Titel oder Nummer)",
         "loadingTranslation": "Übersetzung läuft…"
     },
     "settings": {

--- a/qml/i18n/en.json
+++ b/qml/i18n/en.json
@@ -35,6 +35,7 @@
     },
     "rants": {
         "title": "Rants",
+        "searchPlaceholder": "Search a rant (title or number)",
         "loadingTranslation": "Translating…"
     },
     "settings": {

--- a/qml/i18n/es.json
+++ b/qml/i18n/es.json
@@ -35,6 +35,7 @@
     },
     "rants": {
         "title": "Rants",
+        "searchPlaceholder": "Buscar un rant (título o número)",
         "loadingTranslation": "Traduciendo…"
     },
     "settings": {

--- a/qml/i18n/fr.json
+++ b/qml/i18n/fr.json
@@ -35,6 +35,7 @@
     },
     "rants": {
         "title": "Rants",
+        "searchPlaceholder": "Rechercher un rant (titre ou numéro)",
         "loadingTranslation": "Traduction en cours…"
     },
     "settings": {

--- a/qml/i18n/hi.json
+++ b/qml/i18n/hi.json
@@ -35,6 +35,7 @@
     },
     "rants": {
         "title": "Rants",
+        "searchPlaceholder": "Rant खोजें (शीर्षक या नंबर)",
         "loadingTranslation": "अनुवाद हो रहा है…"
     },
     "settings": {

--- a/qml/i18n/ja.json
+++ b/qml/i18n/ja.json
@@ -35,6 +35,7 @@
     },
     "rants": {
         "title": "Rants",
+        "searchPlaceholder": "ラントを検索(タイトルまたは番号)",
         "loadingTranslation": "翻訳中…"
     },
     "settings": {

--- a/qml/i18n/pt.json
+++ b/qml/i18n/pt.json
@@ -35,6 +35,7 @@
     },
     "rants": {
         "title": "Rants",
+        "searchPlaceholder": "Pesquisar um rant (título ou número)",
         "loadingTranslation": "Traduzindo…"
     },
     "settings": {

--- a/qml/i18n/ru.json
+++ b/qml/i18n/ru.json
@@ -35,6 +35,7 @@
     },
     "rants": {
         "title": "Rants",
+        "searchPlaceholder": "Поиск рассказа (по названию или номеру)",
         "loadingTranslation": "Перевод…"
     },
     "settings": {

--- a/qml/i18n/zh.json
+++ b/qml/i18n/zh.json
@@ -35,6 +35,7 @@
     },
     "rants": {
         "title": "Rants",
+        "searchPlaceholder": "搜索 Rants(标题或编号)",
         "loadingTranslation": "翻译中…"
     },
     "settings": {


### PR DESCRIPTION
Closes #42

## Summary
With rants now fully backfilled (800+, see #37/#38), a few readability gaps showed up:
- Rant body text stretched full-width on the detail pane — capped to ~720px and centered instead. Discussed true multi-column "newspaper" layout with the user; not practical in QtQuick (no column-flow text engine, would complicate the clickable links inside rant content) — went with the single readable-width column, the standard "reader mode" approach.
- Added a search box above the rant list (title/number, same pattern as Dashboard's strip search).
- Added a themed scrollbar to the rant list (previously just clipped with no scroll indicator).

## Test plan
- [x] `qmllint` — only the pre-existing accepted baseline warning category
- [x] Offscreen `qml6` smoke test — clean, no stderr
- [x] All 10 i18n files validated as parseable JSON with `rants.searchPlaceholder` present

🤖 Generated with [Claude Code](https://claude.com/claude-code)