### PR TITLE
feat(gui): persist the Reader's "All strips"/"Main story only" toggle

### DIFF
--- a/gui/src/config.rs
+++ b/gui/src/config.rs
@@ -25,6 +25,12 @@ pub struct GuiConfig {
     pub remote_api_token: String,
     pub poll_interval_minutes: u64,
     pub notifications_enabled: bool,
+    /// The Reader's "All strips" / "Main story only" toggle — a per-install
+    /// UI preference, not daemon state: unlike favorites/reading progress,
+    /// which are meant to follow the user across every client of a shared
+    /// remote daemon, this stays local to whichever GUI installation set
+    /// it.
+    pub main_story_only: bool,
 }
 
 impl Default for GuiConfig {
@@ -36,6 +42,7 @@ impl Default for GuiConfig {
             // daemon_link::poll_interval_minutes's doc comment.
             poll_interval_minutes: 15,
             notifications_enabled: true,
+            main_story_only: false,
         }
     }
 }
@@ -57,6 +64,9 @@ impl GuiConfig {
             notifications_enabled: read_string(&contents, "notifications_enabled")
                 .map(|v| v == "true")
                 .unwrap_or(defaults.notifications_enabled),
+            main_story_only: read_string(&contents, "main_story_only")
+                .map(|v| v == "true")
+                .unwrap_or(defaults.main_story_only),
         }
     }
 
@@ -65,11 +75,12 @@ impl GuiConfig {
             std::fs::create_dir_all(parent)?;
         }
         let contents = format!(
-            "remote_base_url = \"{}\"\nremote_api_token = \"{}\"\npoll_interval_minutes = {}\nnotifications_enabled = {}\n",
+            "remote_base_url = \"{}\"\nremote_api_token = \"{}\"\npoll_interval_minutes = {}\nnotifications_enabled = {}\nmain_story_only = {}\n",
             escape(&self.remote_base_url),
             escape(&self.remote_api_token),
             self.poll_interval_minutes,
             self.notifications_enabled,
+            self.main_story_only,
         );
         std::fs::write(path, contents)
     }
@@ -133,6 +144,7 @@ mod tests {
             remote_api_token: "abc123".to_string(),
             poll_interval_minutes: 30,
             notifications_enabled: false,
+            main_story_only: true,
         };
         config.save(&path).unwrap();
         assert_eq!(GuiConfig::load(&path), config);
@@ -162,5 +174,6 @@ mod tests {
         assert_eq!(config.remote_base_url, "https://x");
         assert_eq!(config.poll_interval_minutes, 15);
         assert!(config.notifications_enabled);
+        assert!(!config.main_story_only);
     }
 }

--- a/gui/src/control.rs
+++ b/gui/src/control.rs
@@ -79,11 +79,12 @@ fn handle_connection(mut stream: TcpStream, expected_token: &str) {
 
 fn config_json(config: &GuiConfig) -> String {
     format!(
-        "{{\"remote_base_url\":\"{}\",\"remote_api_token\":\"{}\",\"poll_interval_minutes\":{},\"notifications_enabled\":{}}}",
+        "{{\"remote_base_url\":\"{}\",\"remote_api_token\":\"{}\",\"poll_interval_minutes\":{},\"notifications_enabled\":{},\"main_story_only\":{}}}",
         json_escape(&config.remote_base_url),
         json_escape(&config.remote_api_token),
         config.poll_interval_minutes,
         config.notifications_enabled,
+        config.main_story_only,
     )
 }
 
@@ -118,6 +119,9 @@ fn route_gui_config(req: &str, path: &std::path::Path) -> (&'static str, String)
             if let Some(v) = extract_query_param(req, "notifications_enabled") {
                 config.notifications_enabled = v == "true";
             }
+            if let Some(v) = extract_query_param(req, "main_story_only") {
+                config.main_story_only = v == "true";
+            }
             match config.save(path) {
                 Ok(()) => ("200 OK", config_json(&config)),
                 Err(err) => (
@@ -150,6 +154,19 @@ mod tests {
         assert_eq!(status, "200 OK");
         assert!(body.contains("\"poll_interval_minutes\":15"));
         assert!(body.contains("\"notifications_enabled\":true"));
+        assert!(body.contains("\"main_story_only\":false"));
+    }
+
+    #[test]
+    fn route_gui_config_post_persists_main_story_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+
+        let (status, body) =
+            route_gui_config("POST /gui-config?main_story_only=true HTTP/1.1\r\n", &path);
+        assert_eq!(status, "200 OK");
+        assert!(body.contains("\"main_story_only\":true"));
+        assert!(GuiConfig::load(&path).main_story_only);
     }
 
     #[test]

--- a/qml/ReaderScreen.qml
+++ b/qml/ReaderScreen.qml
@@ -10,6 +10,7 @@ Item {
     id: root
 
     property var api: null
+    property var guiCtrlApi: null
     property var strips: []
     property var chapters: []
     property var favorites: []
@@ -18,6 +19,11 @@ Item {
 
     property int currentNumber: -1
     property bool mainStoryOnly: false
+    // Guards the very first mainStoryOnly assignment (from loadMainStoryOnly
+    // below) from immediately posting the value straight back to the GUI's
+    // own config — it was just read from there, writing it back is a no-op
+    // that would only race the initial GET.
+    property bool mainStoryOnlyLoaded: false
 
     readonly property var theme: Theme {}
 
@@ -97,7 +103,14 @@ Item {
     // than silently keep showing a strip the active filter excludes.
     // Falls back to the first match if the current one comes before
     // everything in the new list (e.g. mid-prologue bonus content).
+    //
+    // Also persists the toggle to this GUI's own config (see
+    // loadMainStoryOnly below), skipped for the one assignment that
+    // *loads* the persisted value in the first place.
     onMainStoryOnlyChanged: {
+        if (mainStoryOnlyLoaded && root.guiCtrlApi)
+            root.guiCtrlApi.post("/gui-config?main_story_only=" + (mainStoryOnly ? "true" : "false"))
+
         if (currentIndex !== -1)
             return
         var list = filteredStrips
@@ -111,6 +124,29 @@ Item {
         }
         currentNumber = candidate.number
     }
+
+    // Loads the persisted "All strips"/"Main story only" toggle once
+    // guiCtrlApi is ready (see main.qml's verified Component.onCompleted
+    // ordering — the window's own onCompleted, which resolves
+    // guiCtrlApi's real port/token, runs before this screen's). Sets
+    // mainStoryOnlyLoaded first so the onMainStoryOnlyChanged handler
+    // above knows this particular assignment came from the load, not a
+    // user toggle, and doesn't immediately post it straight back.
+    function loadMainStoryOnly() {
+        if (!guiCtrlApi)
+            return
+        guiCtrlApi.get("/gui-config", function (body) {
+            if (body && body.main_story_only)
+                root.mainStoryOnly = true
+            mainStoryOnlyLoaded = true
+        }, function () {
+            // Couldn't read the persisted value — still let later toggles
+            // persist rather than silently never saving for the rest of
+            // this session.
+            mainStoryOnlyLoaded = true
+        })
+    }
+    Component.onCompleted: loadMainStoryOnly()
 
     ColumnLayout {
         anchors.fill: parent

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -230,6 +230,7 @@ ApplicationWindow {
             ReaderScreen {
                 id: readerScreen
                 api: api
+                guiCtrlApi: guiCtrlApi
                 strips: window.strips
                 chapters: window.chapters
                 favorites: window.favorites


### PR DESCRIPTION
Closes #44

## Summary
`mainStoryOnly` was a plain in-memory `ReaderScreen` property, reset every app start. It's a per-install GUI preference, so it now persists through this GUI's own local config — same mechanism Settings already uses for `notifications_enabled` (`GuiConfig`/`GET`+`POST /gui-config` on the local control server), not daemon state (favorites/progress stay daemon-side on purpose, meant to follow the user across every client of a shared remote daemon).

`ReaderScreen` loads the persisted value once `guiCtrlApi` is ready and posts any later toggle back, guarded so the initial load doesn't immediately echo the value it just read.

## Test plan
- [x] `cargo test --workspace`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` all clean, new Rust tests for the config field and route
- [x] `qmllint` on both touched QML files — only the pre-existing accepted baseline warning categories
- [x] Offscreen `qml6` smoke test of the full app — clean, no stderr
- [x] Standalone QML harness verifying the load-vs-toggle distinction: loading the persisted value does not POST it back; a subsequent toggle does

🤖 Generated with [Claude Code](https://claude.com/claude-code)