### PR TITLE
fix(gui): write the GUI config file with owner-only permissions

### DIFF
--- a/gui/src/config.rs
+++ b/gui/src/config.rs
@@ -10,6 +10,8 @@
 
 use std::path::PathBuf;
 
+use megatokyo_core::local_ctrl::write_owner_only_file;
+
 pub fn gui_config_path() -> PathBuf {
     let config_home = std::env::var_os("XDG_CONFIG_HOME")
         .map(PathBuf::from)
@@ -82,7 +84,7 @@ impl GuiConfig {
             self.notifications_enabled,
             self.main_story_only,
         );
-        std::fs::write(path, contents)
+        write_owner_only_file(path, &contents)
     }
 }
 


### PR DESCRIPTION
Closes #50.

`GuiConfig::save` (gui/src/config.rs) wrote `~/.config/megatokyo-gui/config.toml` via plain `std::fs::write` — the file inherited the process umask (typically world-readable). That file holds `remote_api_token`, the same bearer token that authenticates every request to the configured daemon.

Switches to `megatokyo_core::local_ctrl::write_owner_only_file` (mode 0600), matching how the daemon already protects its own `api_token`/`deepl_api_key` in `daemon/src/config.rs`.

## Test plan
- [x] `cargo test -p megatokyo-gui --profile ci` — existing config round-trip tests pass unchanged
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`