### PR TITLE
perf(daemon): reuse one HTTP client for DeepL translation requests

### DIFF
--- a/core/src/translate.rs
+++ b/core/src/translate.rs
@@ -39,8 +39,18 @@ pub struct Translator {
 
 impl Translator {
     pub fn new(api_key: String) -> Self {
+        Self::with_client(reqwest::Client::new(), api_key)
+    }
+
+    /// Same as [`Translator::new`], but reuses a caller-supplied client
+    /// instead of building a fresh one — lets a caller that translates
+    /// repeatedly (e.g. the daemon's `/rant` route, which builds a
+    /// `Translator` fresh per request so a `deepl_api_key` change takes
+    /// effect immediately) keep one connection pool/TLS context across
+    /// calls instead of paying a new handshake to DeepL every time.
+    pub fn with_client(client: reqwest::Client, api_key: String) -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client,
             api_key,
             endpoint_override: None,
         }

--- a/daemon/src/control.rs
+++ b/daemon/src/control.rs
@@ -27,6 +27,9 @@ const TOKEN_HEADER: &str = "x-megatokyo-daemon-token";
 pub struct AppState {
     pub store: Store,
     pub image_cache: ImageCache,
+    /// Reused across translated-rant requests so each one doesn't pay for a
+    /// fresh connection pool/TLS handshake to DeepL — see `route_rant`.
+    pub http_client: reqwest::Client,
     pub token: String,
     /// `deepl_api_key`/`poll_interval_minutes` are editable via `GET`/`POST
     /// /config` (the Settings screen's "this daemon" section) — `bind` and
@@ -239,7 +242,7 @@ async fn route_rant(req: &str, state: &AppState) -> Response {
         let translated = if deepl_api_key.is_empty() {
             Err("no DeepL API key configured".to_string())
         } else {
-            let translator = Translator::new(deepl_api_key);
+            let translator = Translator::with_client(state.http_client.clone(), deepl_api_key);
             get_translated_rant(&state.store, &translator, number, &lang)
                 .await
                 .map_err(|e| e.to_string())
@@ -425,6 +428,7 @@ mod tests {
         AppState {
             store: Store::open_in_memory().unwrap(),
             image_cache: ImageCache::new(std::env::temp_dir()),
+            http_client: reqwest::Client::new(),
             token: "test-token".to_string(),
             config: tokio::sync::RwLock::new(test_config()),
             config_path: std::env::temp_dir().join("megatokyo-test-unused-config.toml"),
@@ -621,6 +625,7 @@ mod tests {
         AppState {
             store: Store::open_in_memory().unwrap(),
             image_cache: ImageCache::new(std::env::temp_dir()),
+            http_client: reqwest::Client::new(),
             token: "test-token".to_string(),
             config: tokio::sync::RwLock::new(test_config()),
             config_path,

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -43,9 +43,12 @@ async fn main() {
         }
     };
 
+    let client = reqwest::Client::new();
+
     let state = Arc::new(AppState {
         store,
         image_cache,
+        http_client: client.clone(),
         token: config.api_token.clone(),
         config: tokio::sync::RwLock::new(config),
         config_path,
@@ -53,7 +56,6 @@ async fn main() {
         check_requested: tokio::sync::Notify::new(),
     });
 
-    let client = reqwest::Client::new();
     let poll_state = state.clone();
     let poll_client = client.clone();
     tokio::spawn(async move {


### PR DESCRIPTION
Closes #52.

`route_rant` (daemon/src/control.rs) built a fresh `Translator::new(deepl_api_key)` on every translated-rant request, and `Translator::new` called `reqwest::Client::new()` — a new connection pool/TLS context per request, discarding keep-alive to the DeepL API.

Rebuilding to read `deepl_api_key` fresh each request is intentional (a key change via `POST /config` should take effect immediately) — only the client itself didn't need rebuilding.

Adds `Translator::with_client` (core/src/translate.rs) and a `http_client: reqwest::Client` field on `AppState`, reused across translation calls and shared with the poll loop's own client (previously created in main.rs but never stored on `AppState`).

## Test plan
- [x] `cargo test --workspace --profile ci` — all existing translate/control tests pass unchanged
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`