### PR TITLE
refactor(gui): dedupe hand-rolled flat-TOML field parsers

### DIFF
--- a/gui/src/background.rs
+++ b/gui/src/background.rs
@@ -15,6 +15,7 @@ use std::time::Duration;
 
 use crate::config::{gui_config_path, GuiConfig};
 use crate::daemon_link::{self, DaemonLink};
+use crate::flat_toml;
 use crate::notification::Notifier;
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -38,8 +39,10 @@ impl LastSeen {
             return Self::default();
         };
         Self {
-            last_strip_number: extract_toml_i32(&contents, "last_strip_number"),
-            last_rant_number: extract_toml_i32(&contents, "last_rant_number"),
+            last_strip_number: flat_toml::raw_value(&contents, "last_strip_number")
+                .and_then(|v| v.parse().ok()),
+            last_rant_number: flat_toml::raw_value(&contents, "last_rant_number")
+                .and_then(|v| v.parse().ok()),
         }
     }
 
@@ -56,13 +59,6 @@ impl LastSeen {
             log::warn!("could not persist {}: {err}", path.display());
         }
     }
-}
-
-fn extract_toml_i32(contents: &str, key: &str) -> Option<i32> {
-    contents.lines().find_map(|line| {
-        let rest = line.trim().strip_prefix(key)?.trim_start();
-        rest.strip_prefix('=')?.trim().parse().ok()
-    })
 }
 
 /// A number only counts as "new" once we have a real baseline to compare

--- a/gui/src/config.rs
+++ b/gui/src/config.rs
@@ -12,6 +12,8 @@ use std::path::PathBuf;
 
 use megatokyo_core::local_ctrl::write_owner_only_file;
 
+use crate::flat_toml;
+
 pub fn gui_config_path() -> PathBuf {
     let config_home = std::env::var_os("XDG_CONFIG_HOME")
         .map(PathBuf::from)
@@ -88,18 +90,14 @@ impl GuiConfig {
     }
 }
 
-/// Same restricted, hand-rolled scalar parsing as `daemon_link`'s
-/// `read_toml_string_field` (no nesting, no multi-line values) — reads
-/// either a quoted string or a bare token (covers this module's own
-/// non-string fields too: `15`, `true`), whichever the line actually has.
+/// Built on [`flat_toml::raw_value`] — reads either a quoted string or a
+/// bare token (covers this module's own non-string fields too: `15`,
+/// `true`), whichever the line actually has.
 fn read_string(contents: &str, key: &str) -> Option<String> {
-    contents.lines().find_map(|line| {
-        let rest = line.trim().strip_prefix(key)?.trim_start();
-        let rest = rest.strip_prefix('=')?.trim();
-        Some(match rest.strip_prefix('"') {
-            Some(quoted) => unescape(quoted.strip_suffix('"')?),
-            None => rest.to_string(),
-        })
+    let rest = flat_toml::raw_value(contents, key)?;
+    Some(match rest.strip_prefix('"') {
+        Some(quoted) => unescape(quoted.strip_suffix('"')?),
+        None => rest.to_string(),
     })
 }
 

--- a/gui/src/daemon_link.rs
+++ b/gui/src/daemon_link.rs
@@ -14,6 +14,8 @@ use std::time::Duration;
 
 use megatokyo_core::local_ctrl;
 
+use crate::flat_toml;
+
 pub struct DaemonLink {
     pub base_url: String,
     pub token: String,
@@ -33,22 +35,6 @@ fn daemon_config_path() -> PathBuf {
     config_home.join("megatokyo-daemon").join("config.toml")
 }
 
-/// Reads `key = "value"`'s value out of a flat TOML file — not a real TOML
-/// parser (no nesting, no escaping beyond a literal `"`), but the daemon's
-/// and this crate's own config files are both flat key/value tables, so
-/// this is all either ever needs. Pulling in the `toml` crate here just for
-/// this would be the one external dependency this binary otherwise has
-/// none of.
-fn read_toml_string_field(contents: &str, key: &str) -> Option<String> {
-    contents.lines().find_map(|line| {
-        let line = line.trim();
-        let rest = line.strip_prefix(key)?.trim_start();
-        let rest = rest.strip_prefix('=')?.trim();
-        let rest = rest.strip_prefix('"')?;
-        rest.strip_suffix('"').map(str::to_string)
-    })
-}
-
 /// `--background` mode's poll interval, read from this GUI's own config —
 /// defaults to matching the daemon's own default (see
 /// `megatokyo-daemon`'s `config::default_poll_interval_minutes`) since
@@ -57,13 +43,9 @@ pub fn poll_interval_minutes() -> u64 {
     std::fs::read_to_string(crate::config::gui_config_path())
         .ok()
         .and_then(|contents| {
-            contents.lines().find_map(|line| {
-                let rest = line
-                    .trim()
-                    .strip_prefix("poll_interval_minutes")?
-                    .trim_start();
-                rest.strip_prefix('=')?.trim().parse().ok()
-            })
+            flat_toml::raw_value(&contents, "poll_interval_minutes")?
+                .parse()
+                .ok()
         })
         .unwrap_or(15)
 }
@@ -71,15 +53,15 @@ pub fn poll_interval_minutes() -> u64 {
 /// Reads this GUI's own config, if a remote daemon override is set there.
 fn configured_remote() -> Option<DaemonLink> {
     let contents = std::fs::read_to_string(crate::config::gui_config_path()).ok()?;
-    let base_url = read_toml_string_field(&contents, "remote_base_url")?;
-    let token = read_toml_string_field(&contents, "remote_api_token")?;
+    let base_url = flat_toml::quoted_string(&contents, "remote_base_url")?;
+    let token = flat_toml::quoted_string(&contents, "remote_api_token")?;
     (!base_url.is_empty() && !token.is_empty()).then_some(DaemonLink { base_url, token })
 }
 
 fn local_daemon_from_config() -> Option<DaemonLink> {
     let contents = std::fs::read_to_string(daemon_config_path()).ok()?;
-    let bind = read_toml_string_field(&contents, "bind")?;
-    let token = read_toml_string_field(&contents, "api_token")?;
+    let bind = flat_toml::quoted_string(&contents, "bind")?;
+    let token = flat_toml::quoted_string(&contents, "api_token")?;
     Some(DaemonLink {
         base_url: format!("http://{bind}"),
         token,
@@ -142,30 +124,4 @@ pub fn resolve() -> Option<DaemonLink> {
 /// this one call.
 pub fn current_uid() -> u32 {
     local_ctrl::current_uid()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn reads_a_quoted_string_field_from_flat_toml() {
-        let toml = "bind = \"127.0.0.1:8420\"\napi_token = \"abc123\"\n";
-        assert_eq!(
-            read_toml_string_field(toml, "bind"),
-            Some("127.0.0.1:8420".to_string())
-        );
-        assert_eq!(
-            read_toml_string_field(toml, "api_token"),
-            Some("abc123".to_string())
-        );
-        assert_eq!(read_toml_string_field(toml, "missing"), None);
-    }
-
-    #[test]
-    fn does_not_confuse_a_key_that_is_a_prefix_of_another() {
-        // "bind" must not match a "bind_extra" line.
-        let toml = "bind_extra = \"nope\"\n";
-        assert_eq!(read_toml_string_field(toml, "bind"), None);
-    }
 }

--- a/gui/src/flat_toml.rs
+++ b/gui/src/flat_toml.rs
@@ -1,0 +1,57 @@
+//! Shared building block for this crate's hand-rolled flat-TOML reads —
+//! `config.rs`, `daemon_link.rs`, and `background.rs` each read a different
+//! flat `key = value` file (this GUI's own config, the daemon's config, and
+//! the background watcher's small state file) but all need the same "find
+//! the line for this key, strip the `key =` prefix" step. Not a real TOML
+//! parser (no nesting, no escaping beyond what each caller handles itself)
+//! — these files are all flat scalar tables, so this is all any of them
+//! ever needs. Pulling in the `toml` crate here would be the one external
+//! dependency this otherwise dependency-light binary has none of (see
+//! Cargo.toml's doc comment).
+
+/// Returns the trimmed right-hand side text of `key`'s line, if `contents`
+/// has one — quotes (if any) are left in place for the caller to strip,
+/// since some fields are quoted strings and others (numbers, booleans)
+/// aren't.
+pub fn raw_value<'a>(contents: &'a str, key: &str) -> Option<&'a str> {
+    contents.lines().find_map(|line| {
+        let rest = line.trim().strip_prefix(key)?.trim_start();
+        rest.strip_prefix('=').map(str::trim)
+    })
+}
+
+/// [`raw_value`], with surrounding `"..."` stripped — for fields that are
+/// always a quoted string with no escaping beyond a literal `"` (this
+/// crate's own config's `escape`d fields aside, which unquote themselves).
+pub fn quoted_string(contents: &str, key: &str) -> Option<String> {
+    let rest = raw_value(contents, key)?;
+    rest.strip_prefix('"')?
+        .strip_suffix('"')
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn raw_value_reads_the_trimmed_right_hand_side() {
+        let toml = "bind = \"127.0.0.1:8420\"\npoll_interval_minutes = 15\n";
+        assert_eq!(raw_value(toml, "bind"), Some("\"127.0.0.1:8420\""));
+        assert_eq!(raw_value(toml, "poll_interval_minutes"), Some("15"));
+        assert_eq!(raw_value(toml, "missing"), None);
+    }
+
+    #[test]
+    fn raw_value_does_not_confuse_a_key_that_is_a_prefix_of_another() {
+        // "bind" must not match a "bind_extra" line.
+        let toml = "bind_extra = \"nope\"\n";
+        assert_eq!(raw_value(toml, "bind"), None);
+    }
+
+    #[test]
+    fn quoted_string_strips_the_surrounding_quotes() {
+        let toml = "api_token = \"abc123\"\n";
+        assert_eq!(quoted_string(toml, "api_token"), Some("abc123".to_string()));
+    }
+}

--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -2,6 +2,7 @@ mod background;
 mod config;
 mod control;
 mod daemon_link;
+mod flat_toml;
 mod launcher;
 mod notification;
 


### PR DESCRIPTION
Closes #53.

Four near-identical hand-rolled `key = value` line scanners existed in gui/src, all following the same `line.trim().strip_prefix(key)?.trim_start().strip_prefix('=')?.trim()` shape:

- `daemon_link.rs`'s `read_toml_string_field` (quoted strings)
- `daemon_link.rs`'s inline `poll_interval_minutes` parsing (unquoted numeric — didn't even reuse the function above, in the same file)
- `config.rs`'s `read_string` (handles both quoted and bare tokens)
- `background.rs`'s `extract_toml_i32`

Adds a `flat_toml` module with `raw_value` (the shared "find this key's line, strip the `key =` prefix" step) and `quoted_string` (its quote-stripping variant); the three call sites now build on it instead of repeating the parsing.

Still deliberately not the `toml` crate — see `gui/Cargo.toml`'s own doc comment on staying dependency-light — just one shared implementation of the common step instead of four.

No behavior change; existing tests (moved to `flat_toml`'s own module where they tested the now-shared logic) still pass.

## Test plan
- [x] `cargo test --workspace --profile ci`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`