### PR TITLE
ci: pin cargo-audit and add an advisory-ignore mechanism

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -49,7 +49,9 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install security tools
-        run: cargo install cargo-audit
+        # Pinned so the job's behavior can't silently change on a new
+        # cargo-audit release — bump deliberately alongside audit.toml.
+        run: cargo install cargo-audit --locked --version 0.22.2
 
       - name: Run cargo-audit
         run: cargo audit

--- a/audit.toml
+++ b/audit.toml
@@ -1,0 +1,9 @@
+# cargo-audit config (.github/workflows/quality.yml's `security` job).
+#
+# Advisories are deliberately ignored here only when they have no upstream
+# fix yet and have been consciously accepted — never to silence a warning
+# that could just be fixed by bumping a dependency. Each entry needs the
+# RUSTSEC id, a one-line reason, and a revisit date; remove the entry once a
+# fixed version is available.
+[advisories]
+ignore = []


### PR DESCRIPTION
Closes #55.

The `security` job in `.github/workflows/quality.yml` installed cargo-audit unpinned (`cargo install cargo-audit`), so the job's behavior could silently change over time on a new release, and there was no sanctioned way to acknowledge a transitive advisory with no upstream fix short of editing the workflow itself.

- Pins the install to `cargo-audit 0.22.2` (`--locked --version`).
- Adds `audit.toml` at the repo root (cargo-audit reads it automatically) as the documented place to record any advisory that needs to be consciously accepted, with a comment explaining when it's appropriate to add an entry. Currently empty — nothing needs ignoring today.

## Test plan
- [x] `cargo install cargo-audit --locked --version 0.22.2 && cargo audit` locally — still passes (251 deps, 0 advisories)