### PR TITLE
ci: add a dependency license check

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -54,6 +54,22 @@ jobs:
       - name: Run cargo-audit
         run: cargo audit
 
+  licenses:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-deny
+        run: cargo install cargo-deny --locked --version 0.20.2
+
+      - name: Check dependency licenses
+        run: cargo deny check licenses
+
   coverage:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,33 @@
+# cargo-deny config (.github/workflows/quality.yml's `licenses` job) — see
+# https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
+#
+# This project ships compiled .deb packages (build-debian.yml,
+# publish-ppa.yml), so an unreviewed transitive dependency license is a real
+# redistribution risk, not just an internal-use nicety. `cargo audit`
+# (the `security` job) only covers known vulnerabilities, not licenses.
+#
+# The allow-list below is every license actually present in Cargo.lock at
+# the time this was written (checked via `cargo metadata`) — permissive
+# licenses plus MPL-2.0 (file-level copyleft, fine to combine with this
+# project's own GPL-3.0-or-later) and Unicode-3.0 (the ICU4X data crates
+# chrono/idna pull in transitively). GPL-3.0-or-later is this workspace's
+# own license (core/daemon/gui), not a dependency's.
+
+[licenses]
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unlicense",
+    "BSL-1.0",
+    "MPL-2.0",
+    "Unicode-3.0",
+    "CDLA-Permissive-2.0",
+    "GPL-3.0-or-later",
+]
+confidence-threshold = 0.9
+
+[graph]
+all-features = true


### PR DESCRIPTION
Closes #56.

`cargo-audit` (the `security` job) only covers known vulnerabilities (RUSTSEC advisories), not dependency licenses. Since this project redistributes compiled `.deb` packages (`build-debian.yml`, `publish-ppa.yml`), an unreviewed transitive dependency license is a real redistribution risk that wasn't covered.

Adds a `licenses` job running `cargo deny check licenses`, with `deny.toml` allow-listing every license actually present in `Cargo.lock` today (checked via `cargo metadata`): the usual permissive set (MIT, Apache-2.0, BSD-2/3-Clause, ISC, Unlicense, BSL-1.0), MPL-2.0 (file-level copyleft, fine alongside this project's own GPL-3.0-or-later), Unicode-3.0 (the ICU4X data crates chrono/idna pull in), CDLA-Permissive-2.0 (`webpki-roots`), and GPL-3.0-or-later itself (this workspace's own crates). A future dependency under an unlisted license fails the job until the allow-list is deliberately updated.

## Test plan
- [x] `cargo install cargo-deny --locked --version 0.20.2 && cargo deny check licenses` locally — `licenses ok`