### PR TITLE
feat(pwa): scaffold a Leptos/WASM mobile PWA client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ Cargo.lock
 **/*.rs.bk
 *.pdb
 
+# Trunk build output (pwa crate)
+/pwa/dist/
+
 # Vendored deps for offline Launchpad/PPA builds (regenerated per release) —
 # not meant to live in git.
 /vendor/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["core", "daemon", "gui"]
+members = ["core", "daemon", "gui", "pwa"]
 
 [workspace.package]
 version = "0.7.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -13,12 +13,20 @@ path = "src/lib.rs"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
-rusqlite = { version = "0.32", features = ["bundled"] }
 thiserror = "2"
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
-scraper = "0.27.0"
-feed-rs = "2.4.0"
-chrono = { version = "0.4.45", default-features = false, features = ["clock"] }
+rusqlite = { version = "0.32", features = ["bundled"], optional = true }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"], optional = true }
+scraper = { version = "0.27.0", optional = true }
+feed-rs = { version = "2.4.0", optional = true }
+chrono = { version = "0.4.45", default-features = false, features = ["clock"], optional = true }
+
+[features]
+default = ["native"]
+# The scraper/store/feed/translate/image_cache modules — everything except
+# `domain` and `local_ctrl`, which stay dependency-light (serde only) so the
+# WASM-targeted `pwa` crate can pull in just the wire-format types without
+# rusqlite (bundled SQLite needs a C toolchain) or the other native-only deps.
+native = ["dep:rusqlite", "dep:reqwest", "dep:scraper", "dep:feed-rs", "dep:chrono"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -4,11 +4,11 @@ pub mod domain;
 // which doesn't exist on wasm32 — and it's server-side (daemon) / local-ctrl
 // (gui) plumbing that the wasm-targeted `pwa` crate has no use for anyway.
 #[cfg(feature = "native")]
-pub mod local_ctrl;
-#[cfg(feature = "native")]
 pub mod feed;
 #[cfg(feature = "native")]
 pub mod image_cache;
+#[cfg(feature = "native")]
+pub mod local_ctrl;
 #[cfg(feature = "native")]
 pub mod scraper;
 #[cfg(feature = "native")]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,7 +1,17 @@
 pub mod domain;
-pub mod feed;
-pub mod image_cache;
+
+// `local_ctrl` uses `std::os::unix` for owner-only config-file permissions,
+// which doesn't exist on wasm32 — and it's server-side (daemon) / local-ctrl
+// (gui) plumbing that the wasm-targeted `pwa` crate has no use for anyway.
+#[cfg(feature = "native")]
 pub mod local_ctrl;
+#[cfg(feature = "native")]
+pub mod feed;
+#[cfg(feature = "native")]
+pub mod image_cache;
+#[cfg(feature = "native")]
 pub mod scraper;
+#[cfg(feature = "native")]
 pub mod store;
+#[cfg(feature = "native")]
 pub mod translate;

--- a/daemon/src/control.rs
+++ b/daemon/src/control.rs
@@ -509,7 +509,9 @@ mod tests {
         let bytes = response.into_bytes();
         let text = String::from_utf8(bytes).unwrap();
         assert!(text.contains("Access-Control-Allow-Origin: *"));
-        assert!(text.contains(&format!("Access-Control-Allow-Headers: {TOKEN_HEADER}, Content-Type")));
+        assert!(text.contains(&format!(
+            "Access-Control-Allow-Headers: {TOKEN_HEADER}, Content-Type"
+        )));
     }
 
     #[tokio::test]

--- a/daemon/src/control.rs
+++ b/daemon/src/control.rs
@@ -72,22 +72,36 @@ async fn handle_connection(mut stream: TcpStream, state: &AppState) -> std::io::
     let req = String::from_utf8_lossy(&buf[..n]).into_owned();
     let path = request_path(&req).to_string();
 
-    let response = if path == "/health" {
-        Response::text("OK")
-    } else {
-        if !is_authorized(&req, &path, &state.token) {
-            Response {
-                status: "403 Forbidden",
-                content_type: "application/json",
-                body: b"{\"ok\":false,\"error\":\"forbidden\"}".to_vec(),
-            }
-        } else {
-            route(&req, &path, state).await
-        }
-    };
+    let response = respond(&req, &path, state).await;
 
     stream.write_all(&response.into_bytes()).await?;
     Ok(())
+}
+
+/// A browser-based client (the PWA) needs CORS: `Response::into_bytes`
+/// stamps every response with the CORS headers, and preflight `OPTIONS`
+/// requests — sent without the app's normal headers, since the browser
+/// strips them before a preflight — are answered here before the `/health`
+/// and auth checks, one level earlier than `/health` already skips auth.
+async fn respond(req: &str, path: &str, state: &AppState) -> Response {
+    if request_method(req) == "OPTIONS" {
+        return Response {
+            status: "204 No Content",
+            content_type: "text/plain",
+            body: Vec::new(),
+        };
+    }
+    if path == "/health" {
+        return Response::text("OK");
+    }
+    if !is_authorized(req, path, &state.token) {
+        return Response {
+            status: "403 Forbidden",
+            content_type: "application/json",
+            body: b"{\"ok\":false,\"error\":\"forbidden\"}".to_vec(),
+        };
+    }
+    route(req, path, state).await
 }
 
 /// Every route but `/health` requires the token header — except `/image`,
@@ -153,8 +167,12 @@ impl Response {
     }
 
     fn into_bytes(self) -> Vec<u8> {
+        // `Access-Control-Allow-Origin: *` is safe here: auth is carried in
+        // a header value (`x-megatokyo-daemon-token`), never a cookie, so
+        // there's no `credentials: include` request for a wildcard origin
+        // to leak.
         let mut out = format!(
-            "HTTP/1.1 {}\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            "HTTP/1.1 {}\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\nAccess-Control-Allow-Origin: *\r\nAccess-Control-Allow-Methods: GET, POST, OPTIONS\r\nAccess-Control-Allow-Headers: {TOKEN_HEADER}, Content-Type\r\n\r\n",
             self.status,
             self.content_type,
             self.body.len()
@@ -474,11 +492,24 @@ mod tests {
 
     async fn route_or_health(req: &str, state: &AppState) -> Response {
         let path = request_path(req).to_string();
-        if path == "/health" {
-            Response::text("OK")
-        } else {
-            route(req, &path, state).await
-        }
+        respond(req, &path, state).await
+    }
+
+    #[tokio::test]
+    async fn options_preflight_is_answered_without_a_token() {
+        let state = state();
+        let response = respond("OPTIONS /chapters HTTP/1.1\r\n", "/chapters", &state).await;
+        assert_eq!(response.status, "204 No Content");
+        assert!(response.body.is_empty());
+    }
+
+    #[test]
+    fn every_response_carries_cors_headers() {
+        let response = Response::text("OK");
+        let bytes = response.into_bytes();
+        let text = String::from_utf8(bytes).unwrap();
+        assert!(text.contains("Access-Control-Allow-Origin: *"));
+        assert!(text.contains(&format!("Access-Control-Allow-Headers: {TOKEN_HEADER}, Content-Type")));
     }
 
     #[tokio::test]

--- a/deny.toml
+++ b/deny.toml
@@ -9,9 +9,11 @@
 # The allow-list below is every license actually present in Cargo.lock at
 # the time this was written (checked via `cargo metadata`) — permissive
 # licenses plus MPL-2.0 (file-level copyleft, fine to combine with this
-# project's own GPL-3.0-or-later) and Unicode-3.0 (the ICU4X data crates
-# chrono/idna pull in transitively). GPL-3.0-or-later is this workspace's
-# own license (core/daemon/gui), not a dependency's.
+# project's own GPL-3.0-or-later), Unicode-3.0 (the ICU4X data crates
+# chrono/idna pull in transitively), and Zlib (OSI-approved/FSF-free,
+# pulled in transitively by the pwa crate's Leptos dependency tree —
+# konst_macro_rules, slotmap). GPL-3.0-or-later is this workspace's own
+# license (core/daemon/gui), not a dependency's.
 
 [licenses]
 allow = [
@@ -25,6 +27,7 @@ allow = [
     "MPL-2.0",
     "Unicode-3.0",
     "CDLA-Permissive-2.0",
+    "Zlib",
     "GPL-3.0-or-later",
 ]
 confidence-threshold = 0.9

--- a/pwa/Cargo.toml
+++ b/pwa/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "megatokyo-pwa"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Mobile PWA client for Megatokyo, talking to the megatokyo-daemon HTTP API"
+
+[dependencies]
+megatokyo-core = { path = "../core", default-features = false }
+leptos = { version = "0.7", features = ["csr"] }
+wasm-bindgen = "0.2"
+gloo-net = "0.6"
+gloo-storage = "0.3"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+web-sys = { version = "0.3", features = ["Window", "Storage"] }
+console_error_panic_hook = "0.1"

--- a/pwa/Trunk.toml
+++ b/pwa/Trunk.toml
@@ -1,0 +1,7 @@
+[build]
+target = "index.html"
+dist = "dist"
+
+[serve]
+port = 8080
+open = false

--- a/pwa/index.html
+++ b/pwa/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Megatokyo</title>
+    <link rel="manifest" href="/manifest.json" />
+    <link rel="icon" href="/icon.svg" />
+    <meta name="theme-color" content="#1b1b1f" />
+    <!-- copy-file (not copy-dir) so these land at dist root, e.g. /sw.js
+         rather than /public/sw.js — a service worker's default control
+         scope is its own directory, and it needs to be "/" to cover the
+         whole app shell. -->
+    <link data-trunk rel="copy-file" href="public/manifest.json" />
+    <link data-trunk rel="copy-file" href="public/icon.svg" />
+    <link data-trunk rel="copy-file" href="public/sw.js" />
+    <link data-trunk rel="rust" data-wasm-opt="0" />
+  </head>
+  <body>
+    <script>
+      if ("serviceWorker" in navigator) {
+        window.addEventListener("load", () => {
+          navigator.serviceWorker.register("/sw.js");
+        });
+      }
+    </script>
+  </body>
+</html>

--- a/pwa/public/icon.svg
+++ b/pwa/public/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192">
+  <rect width="192" height="192" fill="#1b1b1f"/>
+  <text x="96" y="120" font-size="96" text-anchor="middle" fill="#ffffff" font-family="sans-serif">M</text>
+</svg>

--- a/pwa/public/manifest.json
+++ b/pwa/public/manifest.json
@@ -1,0 +1,15 @@
+{
+  "name": "Megatokyo",
+  "short_name": "Megatokyo",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#1b1b1f",
+  "theme_color": "#1b1b1f",
+  "icons": [
+    {
+      "src": "/icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/pwa/public/sw.js
+++ b/pwa/public/sw.js
@@ -1,0 +1,25 @@
+// Minimal service worker: just enough for installability (a page needs an
+// active service worker for the browser to consider it installable). Full
+// offline strip/rant caching is a follow-up, not part of the scaffold.
+const CACHE_NAME = "megatokyo-shell-v1";
+const SHELL_URLS = ["/", "/manifest.json", "/icon.svg"];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(SHELL_URLS))
+  );
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key)))
+    )
+  );
+});
+
+self.addEventListener("fetch", (event) => {
+  event.respondWith(
+    caches.match(event.request).then((cached) => cached || fetch(event.request))
+  );
+});

--- a/pwa/src/daemon_client.rs
+++ b/pwa/src/daemon_client.rs
@@ -1,0 +1,22 @@
+//! Thin client for the `megatokyo-daemon` HTTP API, mirroring the
+//! `x-megatokyo-daemon-token` header convention the desktop GUI already uses
+//! (see `gui/src/background.rs`'s `fetch_status`).
+
+use megatokyo_core::domain::Chapter;
+
+const TOKEN_HEADER: &str = "x-megatokyo-daemon-token";
+
+pub async fn fetch_chapters(base_url: &str, token: &str) -> Result<Vec<Chapter>, String> {
+    let url = format!("{}/chapters", base_url.trim_end_matches('/'));
+    let response = gloo_net::http::Request::get(&url)
+        .header(TOKEN_HEADER, token)
+        .send()
+        .await
+        .map_err(|err| err.to_string())?;
+
+    if !response.ok() {
+        return Err(format!("daemon returned {}", response.status()));
+    }
+
+    response.json::<Vec<Chapter>>().await.map_err(|err| err.to_string())
+}

--- a/pwa/src/daemon_client.rs
+++ b/pwa/src/daemon_client.rs
@@ -18,5 +18,8 @@ pub async fn fetch_chapters(base_url: &str, token: &str) -> Result<Vec<Chapter>,
         return Err(format!("daemon returned {}", response.status()));
     }
 
-    response.json::<Vec<Chapter>>().await.map_err(|err| err.to_string())
+    response
+        .json::<Vec<Chapter>>()
+        .await
+        .map_err(|err| err.to_string())
 }

--- a/pwa/src/main.rs
+++ b/pwa/src/main.rs
@@ -1,0 +1,77 @@
+mod daemon_client;
+mod storage;
+
+use leptos::prelude::*;
+use leptos::task::spawn_local;
+
+fn main() {
+    console_error_panic_hook::set_once();
+    leptos::mount::mount_to_body(App);
+}
+
+#[component]
+fn App() -> impl IntoView {
+    let initial = storage::load();
+    let (base_url, set_base_url) = signal(initial.base_url);
+    let (token, set_token) = signal(initial.token);
+    let (chapters, set_chapters) = signal(None::<Result<Vec<String>, String>>);
+
+    let save_settings = move |_| {
+        storage::save(&storage::DaemonLink {
+            base_url: base_url.get(),
+            token: token.get(),
+        });
+    };
+
+    let load_chapters = move |_| {
+        let base_url = base_url.get();
+        let token = token.get();
+        set_chapters.set(None);
+        spawn_local(async move {
+            let result = daemon_client::fetch_chapters(&base_url, &token)
+                .await
+                .map(|chs| chs.into_iter().map(|c| format!("#{} — {}", c.number, c.title)).collect());
+            set_chapters.set(Some(result));
+        });
+    };
+
+    view! {
+        <main>
+            <h1>"Megatokyo"</h1>
+            <section>
+                <h2>"Daemon settings"</h2>
+                <label>
+                    "Base URL "
+                    <input
+                        type="text"
+                        placeholder="http://127.0.0.1:8420"
+                        prop:value=move || base_url.get()
+                        on:input=move |ev| set_base_url.set(event_target_value(&ev))
+                    />
+                </label>
+                <label>
+                    "Token "
+                    <input
+                        type="password"
+                        prop:value=move || token.get()
+                        on:input=move |ev| set_token.set(event_target_value(&ev))
+                    />
+                </label>
+                <button on:click=save_settings>"Save"</button>
+                <button on:click=load_chapters>"Load chapters"</button>
+            </section>
+            <section>
+                <h2>"Chapters"</h2>
+                {move || match chapters.get() {
+                    None => view! { <p>"Not loaded yet."</p> }.into_any(),
+                    Some(Ok(list)) => view! {
+                        <ul>
+                            {list.into_iter().map(|c| view! { <li>{c}</li> }).collect_view()}
+                        </ul>
+                    }.into_any(),
+                    Some(Err(err)) => view! { <p class="error">{err}</p> }.into_any(),
+                }}
+            </section>
+        </main>
+    }
+}

--- a/pwa/src/main.rs
+++ b/pwa/src/main.rs
@@ -30,7 +30,11 @@ fn App() -> impl IntoView {
         spawn_local(async move {
             let result = daemon_client::fetch_chapters(&base_url, &token)
                 .await
-                .map(|chs| chs.into_iter().map(|c| format!("#{} — {}", c.number, c.title)).collect());
+                .map(|chs| {
+                    chs.into_iter()
+                        .map(|c| format!("#{} — {}", c.number, c.title))
+                        .collect()
+                });
             set_chapters.set(Some(result));
         });
     };

--- a/pwa/src/storage.rs
+++ b/pwa/src/storage.rs
@@ -1,0 +1,27 @@
+//! Persists the remote daemon's base URL and auth token in `localStorage`.
+//! The PWA has no way to spawn a local daemon process the way the desktop
+//! GUI can, so it always operates in "remote daemon" mode — these are the
+//! only two settings it needs, entered once by the user.
+
+use gloo_storage::{LocalStorage, Storage};
+
+const BASE_URL_KEY: &str = "megatokyo_daemon_base_url";
+const TOKEN_KEY: &str = "megatokyo_daemon_token";
+
+#[derive(Debug, Clone, Default)]
+pub struct DaemonLink {
+    pub base_url: String,
+    pub token: String,
+}
+
+pub fn load() -> DaemonLink {
+    DaemonLink {
+        base_url: LocalStorage::get(BASE_URL_KEY).unwrap_or_default(),
+        token: LocalStorage::get(TOKEN_KEY).unwrap_or_default(),
+    }
+}
+
+pub fn save(link: &DaemonLink) {
+    let _ = LocalStorage::set(BASE_URL_KEY, &link.base_url);
+    let _ = LocalStorage::set(TOKEN_KEY, &link.token);
+}


### PR DESCRIPTION
## Summary
- New `pwa` workspace crate (Leptos + Trunk, CSR): a settings form persists the remote daemon's base URL/token in `localStorage`, and a chapters view proves the round-trip against the daemon's HTTP API.
- Splits `megatokyo-core` behind a `native` feature (default-on, no change for `daemon`/`gui`) so the wasm32-targeted `pwa` crate can depend on just the `domain` wire types without pulling in `rusqlite`/`scraper`/`feed-rs`/native `reqwest`.
- Adds CORS + `OPTIONS`-preflight support to the daemon's hand-rolled HTTP server (`control.rs`), which had none — a hard prerequisite for any browser `fetch()` from the PWA's origin to reach it.

Closes #65

## Test plan
- [x] `cargo test --workspace --profile ci` (107 tests pass, including new CORS/OPTIONS coverage in `control.rs`)
- [x] `cargo build --workspace` (native)
- [x] `trunk build` inside `pwa/` (wasm32-unknown-unknown)
- [x] Manual end-to-end: isolated test daemon + `trunk serve`, verified via curl that preflight/authenticated/unauthenticated requests all carry the right CORS headers and the chapters JSON round-trips correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)