### PR TITLE
feat(daemon,pwa): add Web Push notifications (VAPID)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,24 @@
+# cargo-audit config (.github/workflows/quality.yml's `security` job).
+#
+# Lives at `.cargo/audit.toml` — cargo-audit's actual config discovery path
+# (mirroring cargo's own `.cargo/config.toml`), *not* a bare root-level
+# `audit.toml`, which cargo-audit silently never reads. `.cargo/` is
+# otherwise gitignored (vendored offline-build deps), so `.gitignore` carves
+# out an exception for this one file — see its own comment.
+#
+# Advisories are deliberately ignored here only when they have no upstream
+# fix yet and have been consciously accepted — never to silence a warning
+# that could just be fixed by bumping a dependency. Each entry needs the
+# RUSTSEC id, a one-line reason, and a revisit date; remove the entry once a
+# fixed version is available.
+[advisories]
+ignore = [
+    # rsa 0.9.10 (Marvin Attack timing side-channel, no fix available yet) —
+    # pulled in transitively via daemon -> web-push -> jwt-simple ->
+    # superboring's generic RSA JWT support. We only ever construct
+    # ES256KeyPair (P-256/ECDSA) for VAPID signing (see daemon/src/push.rs),
+    # never touching an RSA code path, so the timing side-channel isn't
+    # reachable through our usage. Revisit 2027-02-25 — remove once
+    # jwt-simple/superboring bump past the vulnerable rsa version.
+    "RUSTSEC-2023-0071",
+]

--- a/.github/workflows/build-debian.yml
+++ b/.github/workflows/build-debian.yml
@@ -40,7 +40,8 @@ jobs:
             devscripts \
             quilt \
             lintian \
-            pkg-config
+            pkg-config \
+            libssl-dev
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.gitignore
+++ b/.gitignore
@@ -8,9 +8,14 @@ Cargo.lock
 /pwa/dist/
 
 # Vendored deps for offline Launchpad/PPA builds (regenerated per release) —
-# not meant to live in git.
+# not meant to live in git. `/.cargo/*` + a negation (not a bare `/.cargo/`)
+# so `.cargo/audit.toml` — cargo-audit's actual config discovery path, see
+# audit.toml's own doc comment — can be carved out and tracked; a bare
+# `/.cargo/` would exclude the whole directory as a unit, and git doesn't
+# apply negation patterns to files inside an already-excluded directory.
 /vendor/
-/.cargo/
+/.cargo/*
+!/.cargo/audit.toml
 
 # IDEs
 .vscode/

--- a/audit.toml
+++ b/audit.toml
@@ -1,9 +1,0 @@
-# cargo-audit config (.github/workflows/quality.yml's `security` job).
-#
-# Advisories are deliberately ignored here only when they have no upstream
-# fix yet and have been consciously accepted — never to silence a warning
-# that could just be fixed by bumping a dependency. Each entry needs the
-# RUSTSEC id, a one-line reason, and a revisit date; remove the entry once a
-# fixed version is available.
-[advisories]
-ignore = []

--- a/core/src/domain.rs
+++ b/core/src/domain.rs
@@ -41,3 +41,15 @@ pub struct Favorite {
     pub strip_number: i32,
     pub added_at: String,
 }
+
+/// A browser's Web Push subscription (one per PWA install). Unlike
+/// `Favorite`/`Checking`, this is inherently multi-row even though the
+/// daemon still has no user concept: one shared API token fronts N distinct
+/// per-browser subscriptions, keyed by `endpoint`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PushSubscription {
+    pub endpoint: String,
+    pub p256dh: String,
+    pub auth: String,
+    pub created_at: String,
+}

--- a/core/src/local_ctrl.rs
+++ b/core/src/local_ctrl.rs
@@ -49,16 +49,25 @@ pub fn current_uid() -> u32 {
         .unwrap_or(1000)
 }
 
-/// 64 lowercase hex chars from `/dev/urandom` — used as the daemon's stable
-/// API token, generated once at first boot and persisted in its config.
-/// `read_exact`, not `fs::read`: the latter would block forever on a
-/// character device that never returns EOF.
-pub fn generate_ctrl_token() -> String {
-    let mut buf = [0u8; 32];
+/// `N` random bytes from `/dev/urandom` — shared by [`generate_ctrl_token`]
+/// and the daemon's VAPID keypair generation. `read_exact`, not `fs::read`:
+/// the latter would block forever on a character device that never returns
+/// EOF.
+pub fn random_bytes<const N: usize>() -> [u8; N] {
+    let mut buf = [0u8; N];
     File::open("/dev/urandom")
         .and_then(|mut f| f.read_exact(&mut buf))
-        .expect("unable to read /dev/urandom for the API token");
-    buf.iter().map(|b| format!("{b:02x}")).collect()
+        .expect("unable to read /dev/urandom");
+    buf
+}
+
+/// 64 lowercase hex chars from `/dev/urandom` — used as the daemon's stable
+/// API token, generated once at first boot and persisted in its config.
+pub fn generate_ctrl_token() -> String {
+    random_bytes::<32>()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect()
 }
 
 /// Writes `contents` to `path` readable/writable only by the current user

--- a/core/src/store.rs
+++ b/core/src/store.rs
@@ -14,7 +14,7 @@ use std::sync::Mutex;
 
 use rusqlite::{params, Connection, OptionalExtension};
 
-use crate::domain::{Chapter, Checking, Favorite, Rant, Strip};
+use crate::domain::{Chapter, Checking, Favorite, PushSubscription, Rant, Strip};
 
 #[derive(Debug, thiserror::Error)]
 pub enum StoreError {
@@ -103,6 +103,12 @@ impl Store {
             CREATE TABLE IF NOT EXISTS reading_progress (
                 id INTEGER PRIMARY KEY CHECK (id = 1),
                 strip_number INTEGER NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS push_subscriptions (
+                endpoint TEXT PRIMARY KEY,
+                p256dh TEXT NOT NULL,
+                auth TEXT NOT NULL,
+                created_at TEXT NOT NULL
             );
             ",
         )?;
@@ -379,6 +385,52 @@ impl Store {
         Ok(favorites)
     }
 
+    // -- push subscriptions ---------------------------------------------------
+
+    /// Idempotent: re-subscribing with the same endpoint (e.g. the browser
+    /// re-registering an already-known subscription) just keeps the
+    /// original `created_at`, same reasoning as [`Store::add_favorite`].
+    pub fn add_push_subscription(&self, subscription: &PushSubscription) -> Result<()> {
+        self.conn.lock().unwrap().execute(
+            "INSERT INTO push_subscriptions (endpoint, p256dh, auth, created_at)
+             VALUES (?1, ?2, ?3, ?4)
+             ON CONFLICT(endpoint) DO NOTHING",
+            params![
+                subscription.endpoint,
+                subscription.p256dh,
+                subscription.auth,
+                subscription.created_at
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn remove_push_subscription(&self, endpoint: &str) -> Result<()> {
+        self.conn.lock().unwrap().execute(
+            "DELETE FROM push_subscriptions WHERE endpoint = ?1",
+            params![endpoint],
+        )?;
+        Ok(())
+    }
+
+    pub fn all_push_subscriptions(&self) -> Result<Vec<PushSubscription>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT endpoint, p256dh, auth, created_at FROM push_subscriptions ORDER BY created_at",
+        )?;
+        let subscriptions = stmt
+            .query_map([], |row| {
+                Ok(PushSubscription {
+                    endpoint: row.get(0)?,
+                    p256dh: row.get(1)?,
+                    auth: row.get(2)?,
+                    created_at: row.get(3)?,
+                })
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(subscriptions)
+    }
+
     // -- reading progress -----------------------------------------------------
 
     pub fn get_reading_progress(&self) -> Result<Option<i32>> {
@@ -542,6 +594,69 @@ mod tests {
                 strip_number: 1619,
                 added_at: "2026-08-21T00:00:00Z".to_string()
             }]
+        );
+    }
+
+    fn sample_subscription(endpoint: &str, created_at: &str) -> PushSubscription {
+        PushSubscription {
+            endpoint: endpoint.to_string(),
+            p256dh: "p256dh-key".to_string(),
+            auth: "auth-secret".to_string(),
+            created_at: created_at.to_string(),
+        }
+    }
+
+    #[test]
+    fn push_subscriptions_round_trip_oldest_first() {
+        let store = Store::open_in_memory().unwrap();
+        store
+            .add_push_subscription(&sample_subscription(
+                "https://push.example/b",
+                "2026-08-22T00:00:00Z",
+            ))
+            .unwrap();
+        store
+            .add_push_subscription(&sample_subscription(
+                "https://push.example/a",
+                "2026-08-21T00:00:00Z",
+            ))
+            .unwrap();
+        assert_eq!(
+            store
+                .all_push_subscriptions()
+                .unwrap()
+                .iter()
+                .map(|s| s.endpoint.clone())
+                .collect::<Vec<_>>(),
+            vec!["https://push.example/a", "https://push.example/b"]
+        );
+        store
+            .remove_push_subscription("https://push.example/a")
+            .unwrap();
+        assert_eq!(store.all_push_subscriptions().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn resubscribing_the_same_endpoint_keeps_the_original_created_at() {
+        let store = Store::open_in_memory().unwrap();
+        store
+            .add_push_subscription(&sample_subscription(
+                "https://push.example/a",
+                "2026-08-21T00:00:00Z",
+            ))
+            .unwrap();
+        store
+            .add_push_subscription(&sample_subscription(
+                "https://push.example/a",
+                "2026-08-22T00:00:00Z",
+            ))
+            .unwrap();
+        assert_eq!(
+            store.all_push_subscriptions().unwrap(),
+            vec![sample_subscription(
+                "https://push.example/a",
+                "2026-08-21T00:00:00Z"
+            )]
         );
     }
 

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -8,6 +8,8 @@ repository.workspace = true
 description = "Background service: scrapes megatokyo.com, caches strips/rants/translations, serves the HTTP API"
 
 [dependencies]
+base64 = "0.22"
+bytes = "1"
 chrono = { version = "0.4.45", default-features = false, features = ["clock"] }
 env_logger = "0.11.11"
 log = "0.4.33"
@@ -18,6 +20,11 @@ serde_json = "1.0.151"
 thiserror = "2.0.20"
 tokio = { version = "1.53.1", features = ["full"] }
 toml = "1.1.4"
+# default-features = false: skips the isahc/hyper-tls (OpenSSL-based) HTTP
+# clients this crate offers — we only use its VAPID signing + payload
+# encryption (message-building) API and send via our own rustls-based
+# `reqwest::Client`, matching the reqwest rustls-tls choice above.
+web-push = { version = "0.11.0", default-features = false }
 
 [dev-dependencies]
 tempfile = "3.27.0"

--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -10,6 +10,8 @@ use std::path::PathBuf;
 use megatokyo_core::local_ctrl::{generate_ctrl_token, write_owner_only_file};
 use serde::{Deserialize, Serialize};
 
+use crate::push;
+
 fn default_bind() -> String {
     "127.0.0.1:8420".to_string()
 }
@@ -27,6 +29,24 @@ pub struct Config {
     pub deepl_api_key: String,
     #[serde(default = "default_poll_interval_minutes")]
     pub poll_interval_minutes: u64,
+    /// Base64 URL-safe (no padding) raw private key bytes — the format
+    /// `web_push::VapidSignatureBuilder::from_base64_no_sub` expects
+    /// directly, no PEM/DER round-trip needed.
+    #[serde(default)]
+    pub vapid_private_key: String,
+    /// Uncompressed public key bytes, same base64 encoding as
+    /// `vapid_private_key` — derived from it once at generation time and
+    /// persisted alongside it rather than re-derived on every read, and
+    /// exactly what `GET /push/vapid-public-key` hands the PWA for
+    /// `PushManager.subscribe({applicationServerKey})`.
+    #[serde(default)]
+    pub vapid_public_key: String,
+    /// VAPID JWT `sub` claim (a `mailto:`/URL contact, RFC 8292) — unlike
+    /// the keypair, this can't be self-generated, so it's just another
+    /// operator-editable field like `deepl_api_key`: empty by default, set
+    /// later via `POST /config`. No install-time wizard needed for either.
+    #[serde(default)]
+    pub vapid_subject: String,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -64,19 +84,38 @@ impl Config {
     }
 
     /// Loads the config at `path`, creating it with fresh defaults (and a
-    /// freshly generated `api_token`) if it doesn't exist yet.
+    /// freshly generated `api_token`) if it doesn't exist yet. A config
+    /// written before VAPID support existed parses with empty
+    /// `vapid_private_key`/`vapid_public_key` (`#[serde(default)]`) — those
+    /// get backfilled and persisted here too, so an upgraded daemon gets
+    /// working push on its very next start rather than needing a config
+    /// wipe.
     pub fn load_or_init(path: &std::path::Path) -> Result<Self, ConfigError> {
         match std::fs::read_to_string(path) {
-            Ok(contents) => toml::from_str(&contents).map_err(|source| ConfigError::Parse {
-                path: path.to_path_buf(),
-                source,
-            }),
+            Ok(contents) => {
+                let mut config: Config =
+                    toml::from_str(&contents).map_err(|source| ConfigError::Parse {
+                        path: path.to_path_buf(),
+                        source,
+                    })?;
+                if config.vapid_private_key.is_empty() {
+                    let (private_key, public_key) = push::generate_vapid_keypair();
+                    config.vapid_private_key = private_key;
+                    config.vapid_public_key = public_key;
+                    config.save(path)?;
+                }
+                Ok(config)
+            }
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                let (vapid_private_key, vapid_public_key) = push::generate_vapid_keypair();
                 let config = Config {
                     bind: default_bind(),
                     api_token: generate_ctrl_token(),
                     deepl_api_key: String::new(),
                     poll_interval_minutes: default_poll_interval_minutes(),
+                    vapid_private_key,
+                    vapid_public_key,
+                    vapid_subject: String::new(),
                 };
                 config.save(path)?;
                 Ok(config)
@@ -119,6 +158,31 @@ mod tests {
         assert_eq!(config.bind, "127.0.0.1:8420");
         assert_eq!(config.poll_interval_minutes, 15);
         assert_eq!(config.deepl_api_key, "");
+        assert!(!config.vapid_private_key.is_empty());
+        assert!(!config.vapid_public_key.is_empty());
+        assert_eq!(config.vapid_subject, "");
+    }
+
+    /// A config written before VAPID support existed (just `api_token`, same
+    /// fixture `load_or_init_fills_in_defaults_for_fields_missing_from_an_older_file`
+    /// uses) must come out with a working keypair, backfilled and persisted
+    /// on this very load — not just filled with `#[serde(default)]`'s empty
+    /// strings, which would silently leave push disabled forever.
+    #[test]
+    fn load_or_init_backfills_a_vapid_keypair_for_a_pre_vapid_config_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, "api_token = \"abc123\"\n").unwrap();
+
+        let config = Config::load_or_init(&path).unwrap();
+        assert!(!config.vapid_private_key.is_empty());
+        assert!(!config.vapid_public_key.is_empty());
+
+        // Persisted, not just filled in-memory: a second load sees the same
+        // keypair rather than generating yet another one.
+        let reloaded = Config::load_or_init(&path).unwrap();
+        assert_eq!(reloaded.vapid_private_key, config.vapid_private_key);
+        assert_eq!(reloaded.vapid_public_key, config.vapid_public_key);
     }
 
     #[test]

--- a/daemon/src/control.rs
+++ b/daemon/src/control.rs
@@ -214,6 +214,9 @@ async fn route(req: &str, path: &str, state: &AppState) -> Response {
             Response::ok_json(&serde_json::json!({"ok": true}))
         }
         "/config" => route_config(req, state).await,
+        "/push/vapid-public-key" => route_vapid_public_key(state).await,
+        "/push/subscribe" => route_push_subscribe(req, state).await,
+        "/push/unsubscribe" => route_push_unsubscribe(req, state),
         _ => Response::not_found(),
     }
 }
@@ -396,6 +399,7 @@ async fn route_config(req: &str, state: &AppState) -> Response {
             Response::ok_json(&serde_json::json!({
                 "deepl_api_key": config.deepl_api_key,
                 "poll_interval_minutes": config.poll_interval_minutes,
+                "vapid_subject": config.vapid_subject,
             }))
         }
         "POST" => {
@@ -413,15 +417,71 @@ async fn route_config(req: &str, state: &AppState) -> Response {
                     }
                 }
             }
+            if let Some(subject) = extract_query_param(req, "vapid_subject") {
+                config.vapid_subject = subject;
+            }
             match config.save(&state.config_path) {
                 Ok(()) => Response::ok_json(&serde_json::json!({
                     "deepl_api_key": config.deepl_api_key,
                     "poll_interval_minutes": config.poll_interval_minutes,
+                    "vapid_subject": config.vapid_subject,
                 })),
                 Err(err) => Response::server_error(&err.to_string()),
             }
         }
         _ => Response::not_found(),
+    }
+}
+
+/// Public — no secret involved, just the raw bytes a browser's
+/// `PushManager.subscribe({applicationServerKey})` needs. Serving it from
+/// the daemon instead of hardcoding it in the PWA build means the PWA never
+/// needs rebuilding when the daemon's VAPID keypair changes (or when a
+/// client points at a different daemon entirely).
+async fn route_vapid_public_key(state: &AppState) -> Response {
+    let config = state.config.read().await;
+    if config.vapid_public_key.is_empty() {
+        return Response::server_error("VAPID is not configured on this daemon");
+    }
+    Response::ok_json(&serde_json::json!({ "vapid_public_key": config.vapid_public_key }))
+}
+
+/// `POST /push/subscribe?endpoint=<url-encoded>&p256dh=<base64url>&auth=<base64url>` —
+/// query params rather than a JSON body, matching every other route here:
+/// this hand-rolled server has no JSON-body-parsing plumbing (every existing
+/// `POST`, e.g. `route_favorites`/`route_config`, reads query params only),
+/// and adding one just for this route would be new infrastructure for a
+/// single use. The three fields are exactly what a browser's
+/// `PushSubscription.toJSON()` gives the client (`endpoint`, `keys.p256dh`,
+/// `keys.auth`), just flattened into the URL.
+async fn route_push_subscribe(req: &str, state: &AppState) -> Response {
+    let (Some(endpoint), Some(p256dh), Some(auth)) = (
+        extract_query_param(req, "endpoint"),
+        extract_query_param(req, "p256dh"),
+        extract_query_param(req, "auth"),
+    ) else {
+        return Response::bad_request("endpoint, p256dh and auth are all required");
+    };
+
+    let subscription = megatokyo_core::domain::PushSubscription {
+        endpoint,
+        p256dh,
+        auth,
+        created_at: chrono::Utc::now().to_rfc3339(),
+    };
+    match state.store.add_push_subscription(&subscription) {
+        Ok(()) => Response::ok_json(&serde_json::json!({"ok": true})),
+        Err(err) => Response::server_error(&err.to_string()),
+    }
+}
+
+fn route_push_unsubscribe(req: &str, state: &AppState) -> Response {
+    let Some(endpoint) = extract_query_param(req, "endpoint") else {
+        return Response::bad_request("missing endpoint");
+    };
+    match state.store.remove_push_subscription(&endpoint) {
+        Ok(()) => Response::ok_json(&serde_json::json!({"ok": true})),
+        Err(err) => Response::server_error(&err.to_string()),
     }
 }
 
@@ -431,11 +491,15 @@ mod tests {
     use megatokyo_core::domain::{Chapter, Rant};
 
     fn test_config() -> Config {
+        let (vapid_private_key, vapid_public_key) = crate::push::generate_vapid_keypair();
         Config {
             bind: "127.0.0.1:0".to_string(),
             api_token: "test-token".to_string(),
             deepl_api_key: String::new(),
             poll_interval_minutes: 15,
+            vapid_private_key,
+            vapid_public_key,
+            vapid_subject: String::new(),
         }
     }
 
@@ -614,6 +678,62 @@ mod tests {
         let response = route("GET /favorites HTTP/1.1\r\n", "/favorites", &state).await;
         let body: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
         assert_eq!(body.as_array().unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn vapid_public_key_route_reports_the_configured_key() {
+        let state = state();
+        let expected = state.config.read().await.vapid_public_key.clone();
+
+        let response = route(
+            "GET /push/vapid-public-key HTTP/1.1\r\n",
+            "/push/vapid-public-key",
+            &state,
+        )
+        .await;
+
+        assert_eq!(response.status, "200 OK");
+        let body: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
+        assert_eq!(body["vapid_public_key"], expected);
+    }
+
+    #[tokio::test]
+    async fn push_subscriptions_can_be_added_and_removed() {
+        let state = state();
+        let response = route(
+            "POST /push/subscribe?endpoint=https%3A%2F%2Fpush.example%2Fa&p256dh=key&auth=secret HTTP/1.1\r\n",
+            "/push/subscribe",
+            &state,
+        )
+        .await;
+        assert_eq!(response.status, "200 OK");
+
+        let subscriptions = state.store.all_push_subscriptions().unwrap();
+        assert_eq!(subscriptions.len(), 1);
+        assert_eq!(subscriptions[0].endpoint, "https://push.example/a");
+        assert_eq!(subscriptions[0].p256dh, "key");
+        assert_eq!(subscriptions[0].auth, "secret");
+
+        let response = route(
+            "POST /push/unsubscribe?endpoint=https%3A%2F%2Fpush.example%2Fa HTTP/1.1\r\n",
+            "/push/unsubscribe",
+            &state,
+        )
+        .await;
+        assert_eq!(response.status, "200 OK");
+        assert!(state.store.all_push_subscriptions().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn push_subscribe_requires_all_three_fields() {
+        let state = state();
+        let response = route(
+            "POST /push/subscribe?endpoint=https%3A%2F%2Fpush.example%2Fa HTTP/1.1\r\n",
+            "/push/subscribe",
+            &state,
+        )
+        .await;
+        assert_eq!(response.status, "400 Bad Request");
     }
 
     #[tokio::test]

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -1,6 +1,7 @@
 mod config;
 mod control;
 mod poll;
+mod push;
 
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;

--- a/daemon/src/poll.rs
+++ b/daemon/src/poll.rs
@@ -33,8 +33,11 @@ const RANT_LINK_BASE_URL: &str = "https://megatokyo.com/rant";
 
 /// One full pass: backfill if the store is empty, then a feed diff either
 /// way (a fresh backfill's own scrape can itself lag behind the feed by the
-/// time it finishes, so this isn't an `else`).
-pub async fn run_once(client: &reqwest::Client, state: &AppState) {
+/// time it finishes, so this isn't an `else`). Takes `&Arc<AppState>`
+/// (rather than plain `&AppState`, though it only ever reads through the
+/// `Arc`'s `Deref`) so a new-item push send can clone it into a
+/// `tokio::spawn`ed task.
+pub async fn run_once(client: &reqwest::Client, state: &Arc<AppState>) {
     state.backfilling.store(true, Ordering::Relaxed);
     if let Err(err) = backfill_if_empty(client, &state.store).await {
         log::warn!("backfill failed: {err}");
@@ -44,8 +47,16 @@ pub async fn run_once(client: &reqwest::Client, state: &AppState) {
     }
     state.backfilling.store(false, Ordering::Relaxed);
 
-    if let Err(err) = check_feed(client, &state.store).await {
-        log::warn!("feed check failed: {err}");
+    match check_feed(client, &state.store).await {
+        Ok(new_items) if !new_items.is_empty() => {
+            // Fire-and-forget: a slow/unreachable push service must never
+            // hold up the next poll cycle. `send_to_all` only logs on
+            // failure — see its own doc comment.
+            let state = state.clone();
+            tokio::spawn(async move { crate::push::send_to_all(&state, &new_items).await });
+        }
+        Ok(_) => {}
+        Err(err) => log::warn!("feed check failed: {err}"),
     }
 }
 
@@ -261,11 +272,15 @@ fn store_rants(store: &Store, rants: Vec<Rant>) {
 }
 
 /// Diffs the RSS feed against the stored `checking` checkpoint, backfills
-/// any strip/rant newer than the checkpoint, and advances it.
+/// any strip/rant newer than the checkpoint, and advances it. Returns the
+/// new items (newest-first) so [`run_once`] can push-notify about them —
+/// `check_feed_at` itself stays free of any push/`AppState` concern, same
+/// separation as the rest of this module (only `run_once` touches
+/// `AppState`).
 async fn check_feed(
     client: &reqwest::Client,
     store: &Store,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<Vec<feed::FeedItem>, Box<dyn std::error::Error>> {
     check_feed_at(
         client,
         store,
@@ -285,7 +300,7 @@ async fn check_feed_at(
     feed_url: &str,
     archive_url: &str,
     strip_image_base_url: &str,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<Vec<feed::FeedItem>, Box<dyn std::error::Error>> {
     let items = feed::fetch_at(client, feed_url).await?;
     let mut checking = store.get_checking()?;
     let last_check = checking.last_check.clone().unwrap_or_default();
@@ -318,7 +333,7 @@ async fn check_feed_at(
 
     apply_checkpoint(&mut checking, &new_items);
     store.save_checking(&checking)?;
-    Ok(())
+    Ok(new_items.into_iter().cloned().collect())
 }
 
 /// Advances `checking`'s per-kind last-seen number to the highest number

--- a/daemon/src/push.rs
+++ b/daemon/src/push.rs
@@ -1,0 +1,326 @@
+//! Web Push notifications: VAPID keypair generation and fan-out sends.
+//!
+//! Sends via the daemon's own rustls-based `reqwest::Client` rather than
+//! `web-push`'s built-in clients (`isahc`/`hyper-tls` — see `Cargo.toml`'s
+//! `default-features = false` on the `web-push` dep), avoiding a second,
+//! entirely redundant HTTP-client stack. This does *not* get the daemon out
+//! of needing OpenSSL at build time, though: `web-push`'s payload-encryption
+//! dependency (`ece`, Mozilla's RFC8188 implementation) only has an
+//! OpenSSL-backed crypto backend, no pure-Rust alternative, so it's linked
+//! in regardless — see `debian/control`'s `libssl-dev` Build-Depends, added
+//! alongside this.
+//!
+//! `web_push::clients::request_builder::build_request` builds a generic
+//! `http::Request<T>` (its own `http` v0.2 dependency, not the `http` v1.x
+//! `reqwest` uses — confirmed distinct crate versions in `Cargo.lock`), so
+//! its pieces are translated into a `reqwest::RequestBuilder` by hand below
+//! rather than relying on any direct type-level interop between the two.
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
+use megatokyo_core::domain::PushSubscription;
+use megatokyo_core::feed::{FeedItem, FeedItemKind};
+use megatokyo_core::local_ctrl::random_bytes;
+use web_push::{
+    ContentEncoding, PartialVapidSignatureBuilder, SubscriptionInfo, VapidSignatureBuilder,
+    WebPushMessageBuilder,
+};
+
+use crate::control::AppState;
+
+/// A fresh (private key, public key) pair, both base64 URL-safe/no-padding
+/// encoded — the private key in the raw-scalar format
+/// `VapidSignatureBuilder::from_base64_no_sub` expects directly (no PEM/DER,
+/// no OpenSSL), the public key as the uncompressed point bytes a browser's
+/// `PushManager.subscribe({applicationServerKey})` expects. The retry loop
+/// only ever runs once in practice: a random 32-byte string fails to decode
+/// as a valid P-256 scalar with probability roughly 2^-32 (the curve order
+/// is a hair below 2^256).
+pub fn generate_vapid_keypair() -> (String, String) {
+    loop {
+        let private_key = URL_SAFE_NO_PAD.encode(random_bytes::<32>());
+        if let Ok(builder) = VapidSignatureBuilder::from_base64_no_sub(&private_key) {
+            let public_key = URL_SAFE_NO_PAD.encode(builder.get_public_key());
+            return (private_key, public_key);
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum SendError {
+    #[error("could not build the push message: {0}")]
+    Build(#[from] web_push::WebPushError),
+    #[error("http error: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("push service rejected the request: {0}")]
+    Rejected(String),
+    #[error("subscription is no longer valid")]
+    Gone,
+}
+
+/// Notifies every stored subscription about `items` (from
+/// `poll::check_feed_at`'s new-item diff) — one push per item per
+/// subscription. Meant to be `tokio::spawn`ed by the caller so a slow or
+/// unreachable push service never blocks the poll loop; errors are only
+/// logged here, never propagated. A subscription the push service reports
+/// as gone (410/404 — the browser dropped it) is removed so the daemon
+/// doesn't keep retrying it forever; any other error leaves it alone, since
+/// that's more likely a transient network/service issue than a dead
+/// subscription.
+pub async fn send_to_all(state: &AppState, items: &[FeedItem]) {
+    if items.is_empty() {
+        return;
+    }
+
+    let (vapid_private_key, vapid_subject) = {
+        let config = state.config.read().await;
+        (
+            config.vapid_private_key.clone(),
+            config.vapid_subject.clone(),
+        )
+    };
+    if vapid_private_key.is_empty() {
+        return;
+    }
+    let partial_builder = match VapidSignatureBuilder::from_base64_no_sub(&vapid_private_key) {
+        Ok(builder) => builder,
+        Err(err) => {
+            log::warn!("invalid VAPID private key, skipping push: {err}");
+            return;
+        }
+    };
+
+    let subscriptions = match state.store.all_push_subscriptions() {
+        Ok(subscriptions) => subscriptions,
+        Err(err) => {
+            log::warn!("could not load push subscriptions: {err}");
+            return;
+        }
+    };
+    if subscriptions.is_empty() {
+        return;
+    }
+
+    for item in items {
+        let (title, url) = notification_text(item);
+        for subscription in &subscriptions {
+            let result = send_one(
+                &state.http_client,
+                partial_builder.clone(),
+                &vapid_subject,
+                subscription,
+                &title,
+                &url,
+            )
+            .await;
+            if let Err(err) = result {
+                log::warn!("push to {} failed: {err}", subscription.endpoint);
+                if matches!(err, SendError::Gone) {
+                    if let Err(err) = state.store.remove_push_subscription(&subscription.endpoint) {
+                        log::warn!("could not remove stale push subscription: {err}");
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn notification_text(item: &FeedItem) -> (String, String) {
+    match item.kind {
+        FeedItemKind::Strip => (format!("New strip: {}", item.title), item.link.clone()),
+        FeedItemKind::Rant => (format!("New rant: {}", item.title), item.link.clone()),
+    }
+}
+
+async fn send_one(
+    client: &reqwest::Client,
+    partial_builder: PartialVapidSignatureBuilder,
+    vapid_subject: &str,
+    subscription: &PushSubscription,
+    title: &str,
+    url: &str,
+) -> Result<(), SendError> {
+    let subscription_info = SubscriptionInfo::new(
+        subscription.endpoint.clone(),
+        subscription.p256dh.clone(),
+        subscription.auth.clone(),
+    );
+
+    let mut sig_builder = partial_builder.add_sub_info(&subscription_info);
+    if !vapid_subject.is_empty() {
+        sig_builder.add_claim("sub", vapid_subject);
+    }
+    let signature = sig_builder.build()?;
+
+    let payload = serde_json::json!({ "title": title, "url": url }).to_string();
+    let mut message_builder = WebPushMessageBuilder::new(&subscription_info);
+    message_builder.set_payload(ContentEncoding::Aes128Gcm, payload.as_bytes());
+    message_builder.set_vapid_signature(signature);
+    let message = message_builder.build()?;
+
+    let request = web_push::request_builder::build_request::<bytes::Bytes>(message);
+    let (parts, body) = request.into_parts();
+
+    let method = reqwest::Method::from_bytes(parts.method.as_str().as_bytes())
+        .map_err(|err| SendError::Rejected(err.to_string()))?;
+    let mut builder = client.request(method, parts.uri.to_string());
+    for (name, value) in parts.headers.iter() {
+        builder = builder.header(name.as_str(), value.as_bytes());
+    }
+    let response = builder.body(body.to_vec()).send().await?;
+
+    let status = response.status();
+    if status.is_success() {
+        Ok(())
+    } else if status.as_u16() == 410 || status.as_u16() == 404 {
+        Err(SendError::Gone)
+    } else {
+        let body_text = response.text().await.unwrap_or_default();
+        Err(SendError::Rejected(format!("{status}: {body_text}")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generate_vapid_keypair_produces_a_usable_private_key_and_matching_public_key() {
+        let (private_key, public_key) = generate_vapid_keypair();
+
+        let builder = VapidSignatureBuilder::from_base64_no_sub(&private_key).unwrap();
+        assert_eq!(URL_SAFE_NO_PAD.encode(builder.get_public_key()), public_key);
+        // Uncompressed P-256 point: 0x04 prefix + 32-byte X + 32-byte Y.
+        assert_eq!(URL_SAFE_NO_PAD.decode(&public_key).unwrap().len(), 65);
+    }
+
+    #[test]
+    fn generate_vapid_keypair_varies_between_calls() {
+        let (first, _) = generate_vapid_keypair();
+        let (second, _) = generate_vapid_keypair();
+        assert_ne!(first, second);
+    }
+
+    fn item(number: i32, title: &str) -> FeedItem {
+        FeedItem {
+            kind: FeedItemKind::Strip,
+            number,
+            title: title.to_string(),
+            published_at: "2026-08-25T00:00:00Z".to_string(),
+            link: format!("https://megatokyo.com/strip/{number}"),
+        }
+    }
+
+    /// Any valid P-256 public key works as a stand-in "subscriber" key for
+    /// `ece`'s ECDH step — it doesn't need to be a real browser's key, just
+    /// a real point on the curve, so reusing `generate_vapid_keypair`'s
+    /// output here is the cheapest way to get one.
+    fn fake_subscription(endpoint: String) -> PushSubscription {
+        let (_, p256dh) = generate_vapid_keypair();
+        PushSubscription {
+            endpoint,
+            p256dh,
+            auth: URL_SAFE_NO_PAD.encode(random_bytes::<16>()),
+            created_at: "2026-08-25T00:00:00Z".to_string(),
+        }
+    }
+
+    fn test_state(store: megatokyo_core::store::Store) -> AppState {
+        let (vapid_private_key, vapid_public_key) = generate_vapid_keypair();
+        AppState {
+            store,
+            image_cache: megatokyo_core::image_cache::ImageCache::new(std::env::temp_dir()),
+            http_client: reqwest::Client::new(),
+            token: "test-token".to_string(),
+            config: tokio::sync::RwLock::new(crate::config::Config {
+                bind: "127.0.0.1:0".to_string(),
+                api_token: "test-token".to_string(),
+                deepl_api_key: String::new(),
+                poll_interval_minutes: 15,
+                vapid_private_key,
+                vapid_public_key,
+                vapid_subject: String::new(),
+            }),
+            config_path: std::env::temp_dir().join("megatokyo-test-unused-config.toml"),
+            backfilling: std::sync::atomic::AtomicBool::new(false),
+            check_requested: tokio::sync::Notify::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn send_to_all_posts_to_every_subscription_for_each_new_item() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/ep-a"))
+            .respond_with(wiremock::ResponseTemplate::new(201))
+            .expect(1)
+            .mount(&server)
+            .await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/ep-b"))
+            .respond_with(wiremock::ResponseTemplate::new(201))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let store = megatokyo_core::store::Store::open_in_memory().unwrap();
+        store
+            .add_push_subscription(&fake_subscription(format!("{}/ep-a", server.uri())))
+            .unwrap();
+        store
+            .add_push_subscription(&fake_subscription(format!("{}/ep-b", server.uri())))
+            .unwrap();
+
+        let state = test_state(store);
+        send_to_all(&state, &[item(1619, "Sample")]).await;
+
+        // wiremock's `.expect(1)` on each mock (checked on drop) is the
+        // real assertion here — both endpoints must have been hit exactly
+        // once for this test to pass.
+    }
+
+    #[tokio::test]
+    async fn a_gone_response_removes_the_subscription_but_leaves_others_alone() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/gone"))
+            .respond_with(wiremock::ResponseTemplate::new(410))
+            .mount(&server)
+            .await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/still-valid"))
+            .respond_with(wiremock::ResponseTemplate::new(201))
+            .mount(&server)
+            .await;
+
+        let store = megatokyo_core::store::Store::open_in_memory().unwrap();
+        let gone_endpoint = format!("{}/gone", server.uri());
+        store
+            .add_push_subscription(&fake_subscription(gone_endpoint.clone()))
+            .unwrap();
+        store
+            .add_push_subscription(&fake_subscription(format!("{}/still-valid", server.uri())))
+            .unwrap();
+
+        let state = test_state(store);
+        send_to_all(&state, &[item(1619, "Sample")]).await;
+
+        let remaining = state.store.all_push_subscriptions().unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert_ne!(remaining[0].endpoint, gone_endpoint);
+    }
+
+    #[tokio::test]
+    async fn nothing_is_sent_when_vapid_is_not_configured() {
+        let store = megatokyo_core::store::Store::open_in_memory().unwrap();
+        store
+            .add_push_subscription(&fake_subscription("https://push.example/a".to_string()))
+            .unwrap();
+        let state = test_state(store);
+        state.config.write().await.vapid_private_key = String::new();
+
+        // No mock server at all — if this tried to send anything, it would
+        // fail to connect. Reaching the end without panicking is the test.
+        send_to_all(&state, &[item(1619, "Sample")]).await;
+    }
+}

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,8 @@ Build-Depends:
   cargo,
   rustc,
   pkg-config,
-  build-essential
+  build-essential,
+  libssl-dev
 Standards-Version: 4.6.1
 Homepage: https://github.com/Aarklendoia/megatokyo
 Vcs-Git: https://github.com/Aarklendoia/megatokyo.git

--- a/pwa/Cargo.toml
+++ b/pwa/Cargo.toml
@@ -8,12 +8,28 @@ repository.workspace = true
 description = "Mobile PWA client for Megatokyo, talking to the megatokyo-daemon HTTP API"
 
 [dependencies]
+base64 = "0.22"
 megatokyo-core = { path = "../core", default-features = false }
 leptos = { version = "0.7", features = ["csr"] }
 wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+js-sys = "0.3"
 gloo-net = "0.6"
 gloo-storage = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-web-sys = { version = "0.3", features = ["Window", "Storage"] }
+web-sys = { version = "0.3", features = [
+    "Window",
+    "Storage",
+    "Navigator",
+    "Notification",
+    "NotificationPermission",
+    "ServiceWorkerContainer",
+    "ServiceWorkerRegistration",
+    "PushManager",
+    "PushSubscription",
+    "PushSubscriptionJson",
+    "PushSubscriptionKeys",
+    "PushSubscriptionOptionsInit",
+] }
 console_error_panic_hook = "0.1"

--- a/pwa/public/sw.js
+++ b/pwa/public/sw.js
@@ -23,3 +23,41 @@ self.addEventListener("fetch", (event) => {
     caches.match(event.request).then((cached) => cached || fetch(event.request))
   );
 });
+
+// Payload shape is `{"title": ..., "url": ...}` — see daemon/src/push.rs's
+// `send_one`. `event.waitUntil` keeps the service worker alive until the
+// notification is actually shown; without it the browser can kill the
+// worker mid-`showNotification` on some platforms.
+self.addEventListener("push", (event) => {
+  const data = event.data ? event.data.json() : {};
+  const title = data.title || "Megatokyo";
+  event.waitUntil(
+    self.registration.showNotification(title, {
+      body: data.url || "",
+      icon: "/icon.svg",
+      data: { url: data.url || "/" },
+    })
+  );
+});
+
+// Focuses an already-open client on the notification's URL rather than
+// always opening a new tab/window.
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  const url = event.notification.data && event.notification.data.url;
+  if (!url) return;
+  event.waitUntil(
+    self.clients
+      .matchAll({ type: "window", includeUncontrolled: true })
+      .then((clients) => {
+        for (const client of clients) {
+          if (client.url === url && "focus" in client) {
+            return client.focus();
+          }
+        }
+        if (self.clients.openWindow) {
+          return self.clients.openWindow(url);
+        }
+      })
+  );
+});

--- a/pwa/src/daemon_client.rs
+++ b/pwa/src/daemon_client.rs
@@ -3,6 +3,7 @@
 //! (see `gui/src/background.rs`'s `fetch_status`).
 
 use megatokyo_core::domain::Chapter;
+use serde::Deserialize;
 
 const TOKEN_HEADER: &str = "x-megatokyo-daemon-token";
 
@@ -22,4 +23,56 @@ pub async fn fetch_chapters(base_url: &str, token: &str) -> Result<Vec<Chapter>,
         .json::<Vec<Chapter>>()
         .await
         .map_err(|err| err.to_string())
+}
+
+#[derive(Deserialize)]
+struct VapidPublicKeyResponse {
+    vapid_public_key: String,
+}
+
+pub async fn fetch_vapid_public_key(base_url: &str, token: &str) -> Result<String, String> {
+    let url = format!("{}/push/vapid-public-key", base_url.trim_end_matches('/'));
+    let response = gloo_net::http::Request::get(&url)
+        .header(TOKEN_HEADER, token)
+        .send()
+        .await
+        .map_err(|err| err.to_string())?;
+
+    if !response.ok() {
+        return Err(format!("daemon returned {}", response.status()));
+    }
+
+    response
+        .json::<VapidPublicKeyResponse>()
+        .await
+        .map(|body| body.vapid_public_key)
+        .map_err(|err| err.to_string())
+}
+
+/// `endpoint`/`p256dh`/`auth` are exactly what the browser's
+/// `PushSubscription.toJSON()` gives — see `push::subscribe`. Only
+/// `endpoint` needs percent-encoding: `p256dh`/`auth` are already
+/// URL-safe base64.
+pub async fn push_subscribe(
+    base_url: &str,
+    token: &str,
+    endpoint: &str,
+    p256dh: &str,
+    auth: &str,
+) -> Result<(), String> {
+    let encoded_endpoint = js_sys::encode_uri_component(endpoint);
+    let url = format!(
+        "{}/push/subscribe?endpoint={encoded_endpoint}&p256dh={p256dh}&auth={auth}",
+        base_url.trim_end_matches('/'),
+    );
+    let response = gloo_net::http::Request::post(&url)
+        .header(TOKEN_HEADER, token)
+        .send()
+        .await
+        .map_err(|err| err.to_string())?;
+
+    if !response.ok() {
+        return Err(format!("daemon returned {}", response.status()));
+    }
+    Ok(())
 }

--- a/pwa/src/main.rs
+++ b/pwa/src/main.rs
@@ -1,4 +1,5 @@
 mod daemon_client;
+mod push;
 mod storage;
 
 use leptos::prelude::*;
@@ -15,11 +16,22 @@ fn App() -> impl IntoView {
     let (base_url, set_base_url) = signal(initial.base_url);
     let (token, set_token) = signal(initial.token);
     let (chapters, set_chapters) = signal(None::<Result<Vec<String>, String>>);
+    let (notifications_status, set_notifications_status) = signal(None::<Result<(), String>>);
 
     let save_settings = move |_| {
         storage::save(&storage::DaemonLink {
             base_url: base_url.get(),
             token: token.get(),
+        });
+    };
+
+    let enable_notifications = move |_| {
+        let base_url = base_url.get();
+        let token = token.get();
+        set_notifications_status.set(None);
+        spawn_local(async move {
+            let result = push::subscribe(&base_url, &token).await;
+            set_notifications_status.set(Some(result));
         });
     };
 
@@ -63,6 +75,12 @@ fn App() -> impl IntoView {
                 </label>
                 <button on:click=save_settings>"Save"</button>
                 <button on:click=load_chapters>"Load chapters"</button>
+                <button on:click=enable_notifications>"Enable notifications"</button>
+                {move || match notifications_status.get() {
+                    None => ().into_any(),
+                    Some(Ok(())) => view! { <p>"Notifications enabled."</p> }.into_any(),
+                    Some(Err(err)) => view! { <p class="error">{err}</p> }.into_any(),
+                }}
             </section>
             <section>
                 <h2>"Chapters"</h2>

--- a/pwa/src/push.rs
+++ b/pwa/src/push.rs
@@ -1,0 +1,70 @@
+//! Web Push subscribe flow: request notification permission, subscribe via
+//! the service worker's `PushManager` using the daemon's VAPID public key,
+//! then register the resulting subscription with the daemon.
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
+use wasm_bindgen::JsCast;
+use wasm_bindgen_futures::JsFuture;
+use web_sys::{PushManager, PushSubscriptionOptionsInit, ServiceWorkerRegistration};
+
+use crate::daemon_client;
+
+pub async fn subscribe(base_url: &str, token: &str) -> Result<(), String> {
+    let vapid_public_key = daemon_client::fetch_vapid_public_key(base_url, token).await?;
+
+    let permission = request_notification_permission().await?;
+    if permission != "granted" {
+        return Err("notification permission was not granted".to_string());
+    }
+
+    let registration = service_worker_registration().await?;
+    let push_manager: PushManager = registration.push_manager().map_err(js_err)?;
+
+    let key_bytes = URL_SAFE_NO_PAD
+        .decode(&vapid_public_key)
+        .map_err(|err| err.to_string())?;
+    let key_array = js_sys::Uint8Array::from(key_bytes.as_slice());
+
+    let options = PushSubscriptionOptionsInit::new();
+    options.set_user_visible_only(true);
+    options.set_application_server_key_opt_u8_array(Some(&key_array));
+
+    let subscription = JsFuture::from(
+        push_manager
+            .subscribe_with_options(&options)
+            .map_err(js_err)?,
+    )
+    .await
+    .map_err(js_err)?;
+    let subscription: web_sys::PushSubscription = subscription.unchecked_into();
+
+    let json = subscription.to_json().map_err(js_err)?;
+    let endpoint = json.get_endpoint().ok_or("subscription has no endpoint")?;
+    let keys = json.get_keys().ok_or("subscription has no keys")?;
+    let p256dh = keys.get_p256dh().ok_or("subscription has no p256dh key")?;
+    let auth = keys.get_auth().ok_or("subscription has no auth key")?;
+
+    daemon_client::push_subscribe(base_url, token, &endpoint, &p256dh, &auth).await
+}
+
+async fn request_notification_permission() -> Result<String, String> {
+    let promise = web_sys::Notification::request_permission().map_err(js_err)?;
+    let result = JsFuture::from(promise).await.map_err(js_err)?;
+    Ok(result.as_string().unwrap_or_default())
+}
+
+/// `navigator.serviceWorker.ready` — waits for the service worker
+/// registered in `index.html` to become active, rather than assuming it
+/// already is (it may still be installing on a first visit).
+async fn service_worker_registration() -> Result<ServiceWorkerRegistration, String> {
+    let window = web_sys::window().ok_or("no window")?;
+    let container = window.navigator().service_worker();
+    let promise = container.ready().map_err(js_err)?;
+    let registration = JsFuture::from(promise).await.map_err(js_err)?;
+    Ok(registration.unchecked_into())
+}
+
+fn js_err(err: wasm_bindgen::JsValue) -> String {
+    err.as_string().unwrap_or_else(|| format!("{err:?}"))
+}


### PR DESCRIPTION
## Summary
- Daemon generates and persists its own VAPID keypair on first boot (`load_or_init`, same pattern as `api_token`), and backfills it for any pre-existing config — no install-time wizard, VAPID is self-sovereign (RFC 8292).
- New `push_subscriptions` table (mirrors `favorites`) + three routes: `GET /push/vapid-public-key`, `POST /push/subscribe`, `POST /push/unsubscribe` — query params, matching every other route on this hand-rolled server.
- A fan-out send hooked into the poll loop's existing new-item diff (`check_feed_at`) — one push per new strip/rant per subscription, fire-and-forget via `tokio::spawn` so a slow/unreachable push service never blocks the next poll cycle. A `410`/`404` response prunes the stale subscription.
- Sends via the daemon's own rustls `reqwest::Client` rather than `web-push`'s built-in clients (`isahc`/`hyper-tls`, both OpenSSL-backed) — `default-features = false` avoids that redundant second HTTP-client stack. This does **not** get us out of OpenSSL entirely though: `web-push`'s payload-encryption dependency (`ece`) only has an OpenSSL backend, so `libssl-dev` was added to `debian/control`'s Build-Depends and the `build-debian.yml` CI step.
- PWA: an "Enable notifications" button drives the subscribe flow (permission request → fetch the daemon's public key → `PushManager.subscribe` → register with the daemon), and the service worker gained `push`/`notificationclick` handlers.

### Side fix found along the way
`cargo-audit` reads its config from `.cargo/audit.toml`, not a root-level `audit.toml` — but `.cargo/` was wholesale gitignored (for vendored offline-build deps), so the advisory-ignore mechanism added in #62 had silently never been in effect. Moved the config to `.cargo/audit.toml` with a targeted `.gitignore` carve-out, and used it to accept `RUSTSEC-2023-0071` (an RSA timing side-channel in a `jwt-simple` dependency we never exercise — VAPID here only ever uses ES256/P-256).

Closes #66

## Test plan
- [x] `cargo test --workspace --profile ci` (all suites pass, including new VAPID/push-route/send tests — the send tests use `wiremock` for a real encrypt+sign+send round trip, plus a 410-cleanup case)
- [x] `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo deny check licenses`, `cargo audit` all clean locally
- [x] `trunk build` (wasm32) succeeds for the pwa crate
- [x] Manual end-to-end against an isolated test daemon (separate config/port from the real system daemon): confirmed the pre-VAPID-config backfill path generates and persists a working keypair, `GET /push/vapid-public-key`, `POST /push/subscribe`/`unsubscribe`, and `POST /config?vapid_subject=...` all work as expected via curl

🤖 Generated with [Claude Code](https://claude.com/claude-code)