### PR TITLE
feat(gui): add AppStream MetaInfo for megatokyo-gui

### DIFF
--- a/debian/megatokyo-gui.install
+++ b/debian/megatokyo-gui.install
@@ -1,3 +1,4 @@
 usr/bin/megatokyo-gui
 usr/lib/systemd/user/megatokyo-gui-background.service
 megatokyo.desktop usr/share/applications
+megatokyo.metainfo.xml usr/share/metainfo

--- a/megatokyo.metainfo.xml
+++ b/megatokyo.metainfo.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>megatokyo.desktop</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <name>Megatokyo</name>
+  <summary>Megatokyo webcomic reader</summary>
+  <description>
+    <p>
+      A QML client for browsing the Megatokyo webcomic by chapter or strip,
+      reading the author's rants with on-demand translation, and getting
+      notified when a new strip or rant goes up.
+    </p>
+    <p>
+      Talks to a megatokyo-daemon instance, local (installed automatically
+      via the package's Recommends) or remote (configured in Settings).
+    </p>
+  </description>
+  <launchable type="desktop-id">megatokyo.desktop</launchable>
+  <developer id="com.aarklendoia">
+    <name>Aarklendoïa</name>
+  </developer>
+  <categories>
+    <category>Network</category>
+  </categories>
+  <url type="homepage">https://github.com/Aarklendoia/megatokyo</url>
+  <url type="bugtracker">https://github.com/Aarklendoia/megatokyo/issues</url>
+  <provides>
+    <binary>megatokyo-gui</binary>
+  </provides>
+  <content_rating type="oars-1.1" />
+  <releases>
+    <release version="0.7.1" date="2026-08-25" />
+  </releases>
+</component>

--- a/megatokyo.metainfo.xml
+++ b/megatokyo.metainfo.xml
@@ -29,7 +29,4 @@
     <binary>megatokyo-gui</binary>
   </provides>
   <content_rating type="oars-1.1" />
-  <releases>
-    <release version="0.7.1" date="2026-08-25" />
-  </releases>
 </component>


### PR DESCRIPTION
## Summary
- Add `megatokyo.metainfo.xml` (AppStream MetaInfo) for `megatokyo-gui`, installed to `/usr/share/metainfo/`
- Lets Discover show the app with a proper name/description/icon once installed, instead of falling back to a bare `.desktop` entry

## Test plan
- [x] `appstreamcli validate megatokyo.metainfo.xml` — passes except a non-blocking reverse-DNS ID style warning (kept in sync with the existing `.desktop` file's id)

🤖 Generated with [Claude Code](https://claude.com/claude-code)